### PR TITLE
test: add comprehensive CLI and package test coverage (88.5%)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,13 +12,13 @@ coverage:
   round: down
   range: "60...100"
 
-  ignore:
-    - cmd/**                           # trivial main(), covered by E2E
-    - internal/version/**              # build-time ldflags injection
-    - internal/testutil/**             # test helpers, not themselves tested
-    - queries/**                       # go:embed directive
-    - internal/config/paths_windows.go # platform-specific, CI runs Linux/macOS
-    - internal/doctor/permission_windows.go
+ignore:
+  - cmd/**                           # trivial main(), covered by E2E
+  - internal/version/**              # build-time ldflags injection
+  - internal/testutil/**             # test helpers, not themselves tested
+  - queries/**                       # go:embed directive
+  - internal/config/paths_windows.go # platform-specific, CI runs Linux/macOS
+  - internal/doctor/permission_windows.go
 
 component_management:
   individual_components:

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,14 @@ coverage:
   round: down
   range: "60...100"
 
+  ignore:
+    - cmd/**                           # trivial main(), covered by E2E
+    - internal/version/**              # build-time ldflags injection
+    - internal/testutil/**             # test helpers, not themselves tested
+    - queries/**                       # go:embed directive
+    - internal/config/paths_windows.go # platform-specific, CI runs Linux/macOS
+    - internal/doctor/permission_windows.go
+
 component_management:
   individual_components:
     - component_id: cmd

--- a/internal/cli/accounts_test.go
+++ b/internal/cli/accounts_test.go
@@ -1,0 +1,713 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestAccounts(t *testing.T) {
+	t.Run("list", testAccountsListJSON)
+	t.Run("list_api_error", testAccountsListAPIError)
+	t.Run("show", testAccountsShowJSON)
+	t.Run("types", testAccountsTypesJSON)
+	t.Run("holdings", testAccountsHoldingsJSON)
+	t.Run("holdings_missing_arg", testAccountsHoldingsMissingArg)
+	t.Run("balance_at", testAccountsBalanceAtJSON)
+	t.Run("history", testAccountsHistoryJSON)
+	t.Run("refresh", testAccountsRefreshJSON)
+	t.Run("refresh_status", testAccountsRefreshStatusJSON)
+	t.Run("update", testAccountsUpdateJSON)
+	t.Run("delete", testAccountsDeleteJSON)
+	t.Run("create_manual", testAccountsCreateManualJSON)
+	t.Run("upload_history", testAccountsUploadHistoryJSON)
+	t.Run("recent_balances", testAccountsRecentBalancesJSON)
+	t.Run("snapshots", testAccountsSnapshotsJSON)
+	t.Run("aggregate_snapshots", testAccountsAggregateSnapshotsJSON)
+	t.Run("networth", testNetworthJSON)
+}
+
+func testAccountsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAccounts" {
+			t.Fatalf("operation = %q, want GetAccounts", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"accounts":[{"id":"a1","displayName":"Checking","type":{"name":"bank","display":"Bank"},"subtype":{"name":"checking","display":"Checking"},"displayBalance":42.5,"currentBalance":42.5,"updatedAt":"2026-05-01","isHidden":false,"isAsset":true,"mask":"1234","isManual":false}]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsListCmd.Run(accountsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"display_name":"Checking"`) {
+		t.Fatalf("output missing display name = %q", out)
+	}
+	if !strings.Contains(out, `"display_balance":42.5`) {
+		t.Fatalf("output missing balance = %q", out)
+	}
+}
+
+func testAccountsListAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsListCmd.Run(accountsListCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}
+
+func testAccountsShowJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsShowCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAccount" {
+			t.Fatalf("operation = %q, want GetAccount", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["id"] != "acc-1" {
+			t.Fatalf("variables = %#v, want id=acc-1", gqlReq.Variables)
+		}
+		return testutil.JSONResponse(`{"data":{"account":{"id":"acc-1","displayName":"Cash","type":{"name":"cash","display":"Cash"},"subtype":{"name":"cash","display":"Cash"},"displayBalance":9.5,"currentBalance":9.5,"updatedAt":"2026-05-01","isHidden":false,"isAsset":true,"mask":"","isManual":true}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsShowCmd.Run(accountsShowCmd, []string{"acc-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.show"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"display_name":"Cash"`) {
+		t.Fatalf("output missing display name = %q", out)
+	}
+	if !strings.Contains(out, `"display_balance":9.5`) {
+		t.Fatalf("output missing balance = %q", out)
+	}
+}
+
+func testAccountsTypesJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsTypesCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAccountTypeOptions" {
+			t.Fatalf("operation = %q, want GetAccountTypeOptions", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"accountTypes":[{"name":"bank","display":"Bank"},{"name":"credit","display":"Credit"}]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsTypesCmd.Run(accountsTypesCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.types"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, "bank") {
+		t.Fatalf("output missing bank type = %q", out)
+	}
+	if !strings.Contains(out, "credit") {
+		t.Fatalf("output missing credit type = %q", out)
+	}
+}
+
+func testAccountsHoldingsJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsHoldingsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Web_GetHoldings" {
+			t.Fatalf("operation = %q, want Web_GetHoldings", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"portfolio":{"aggregateHoldings":{"edges":[{"node":{"id":"h1","quantity":2,"basis":3,"totalValue":6,"holdings":[{"id":"sub-1","quantity":2,"name":"VTI","ticker":"VTI","account":{"id":"acc-1"}}]}}]}}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsHoldingsCmd.Run(accountsHoldingsCmd, []string{"acc-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.holdings"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"id":"h1"`) {
+		t.Fatalf("output missing holding id = %q", out)
+	}
+	if !strings.Contains(out, `"total_value":6`) {
+		t.Fatalf("output missing total value = %q", out)
+	}
+}
+
+func testAccountsHoldingsMissingArg(t *testing.T) {
+	// cobra.ExactArgs(1) is enforced by Execute(), not Run().
+	// Calling Run directly with nil args would panic on args[0].
+	// Verify the command declares the arg requirement.
+	if accountsHoldingsCmd.Args == nil {
+		t.Fatal("accountsHoldingsCmd.Args is nil, want cobra.ExactArgs(1)")
+	}
+	argsErr := accountsHoldingsCmd.Args(accountsHoldingsCmd, nil)
+	if argsErr == nil {
+		t.Fatal("Expected arg validation error for nil args, got nil")
+	}
+}
+
+func testAccountsBalanceAtJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsBalanceAtCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Common_GetDisplayBalanceAtDate" {
+			t.Fatalf("operation = %q, want Common_GetDisplayBalanceAtDate", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["date"] != "2026-05-10" {
+			t.Fatalf("variables = %#v, want date=2026-05-10", gqlReq.Variables)
+		}
+		return testutil.JSONResponse(`{"data":{"accounts":[{"id":"a1","displayName":"Checking","displayBalance":42.25,"type":{"name":"cash","group":"asset"}}]}}`), nil
+	})
+
+	balanceAtDate = ""
+	_ = accountsBalanceAtCmd.Flags().Set("date", "2026-05-10")
+	out := captureStdout(t, func() {
+		accountsBalanceAtCmd.Run(accountsBalanceAtCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.balance-at"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"display_name":"Checking"`) {
+		t.Fatalf("output missing display name = %q", out)
+	}
+	if !strings.Contains(out, `"display_balance":42.25`) {
+		t.Fatalf("output missing balance = %q", out)
+	}
+}
+
+func testAccountsHistoryJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsHistoryCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAccountHistory" {
+			t.Fatalf("operation = %q, want GetAccountHistory", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregateSnapshots":[{"date":"2026-05-01","balance":10},{"date":"2026-05-02","balance":20}]}}`), nil
+	})
+
+	historyFrom = ""
+	historyTo = ""
+	_ = accountsHistoryCmd.Flags().Set("from", "2026-05-01")
+	_ = accountsHistoryCmd.Flags().Set("to", "2026-05-31")
+	out := captureStdout(t, func() {
+		accountsHistoryCmd.Run(accountsHistoryCmd, []string{"acc-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.history"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"date":"2026-05-01"`) {
+		t.Fatalf("output missing date = %q", out)
+	}
+	if !strings.Contains(out, `"amount":10`) {
+		t.Fatalf("output missing amount = %q", out)
+	}
+}
+
+func testAccountsRefreshJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, accountsRefreshCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "RefreshAccounts" {
+			t.Fatalf("operation = %q, want RefreshAccounts", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"requestAccountsRefresh":{"ok":true}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsRefreshCmd.Run(accountsRefreshCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.refresh"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"refresh requested"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testAccountsRefreshStatusJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsRefreshStatusCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAccountsRefreshStatus" {
+			t.Fatalf("operation = %q, want GetAccountsRefreshStatus", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"accounts":[{"id":"a1","hasSyncInProgress":false}]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsRefreshStatusCmd.Run(accountsRefreshStatusCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.refresh-status"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"is_complete":true`) {
+		t.Fatalf("output missing is_complete = %q", out)
+	}
+}
+
+func testAccountsUpdateJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, accountsUpdateCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "UpdateAccount" {
+			t.Fatalf("operation = %q, want UpdateAccount", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["id"] != "acc-1" {
+			t.Fatalf("variables = %#v, want id=acc-1", gqlReq.Variables)
+		}
+		return testutil.JSONResponse(`{"data":{"updateAccount":{"account":{"id":"acc-1","displayName":"New","displayBalance":100}}}}`), nil
+	})
+
+	accountName = ""
+	accountBalance = 0
+	_ = accountsUpdateCmd.Flags().Set("name", "New")
+	_ = accountsUpdateCmd.Flags().Set("balance", "100")
+	out := captureStdout(t, func() {
+		accountsUpdateCmd.Run(accountsUpdateCmd, []string{"acc-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.update"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"display_name":"New"`) {
+		t.Fatalf("output missing display name = %q", out)
+	}
+	if !strings.Contains(out, `"display_balance":100`) {
+		t.Fatalf("output missing balance = %q", out)
+	}
+}
+
+func testAccountsDeleteJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, accountsDeleteCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "DeleteAccount" {
+			t.Fatalf("operation = %q, want DeleteAccount", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["id"] != "acc-1" {
+			t.Fatalf("variables = %#v, want id=acc-1", gqlReq.Variables)
+		}
+		return testutil.JSONResponse(`{"data":{"deleteAccount":{"ok":true}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsDeleteCmd.Run(accountsDeleteCmd, []string{"acc-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.delete"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"deleted"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testAccountsCreateManualJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, accountsCreateManualCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "CreateManualAccount" {
+			t.Fatalf("operation = %q, want CreateManualAccount", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["name"] != "Savings" {
+			t.Fatalf("variables = %#v, want name=Savings", gqlReq.Variables)
+		}
+		if gqlReq.Variables["type"] != "cash" {
+			t.Fatalf("variables = %#v, want type=cash", gqlReq.Variables)
+		}
+		return testutil.JSONResponse(`{"data":{"createManualAccount":{"account":{"id":"a2","displayName":"Savings","displayBalance":10}}}}`), nil
+	})
+
+	accountName = ""
+	accountType = ""
+	accountBalance = 0
+	_ = accountsCreateManualCmd.Flags().Set("name", "Savings")
+	_ = accountsCreateManualCmd.Flags().Set("type", "cash")
+	_ = accountsCreateManualCmd.Flags().Set("balance", "10")
+	out := captureStdout(t, func() {
+		accountsCreateManualCmd.Run(accountsCreateManualCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.create-manual"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"display_name":"Savings"`) {
+		t.Fatalf("output missing display name = %q", out)
+	}
+	if !strings.Contains(out, `"display_balance":10`) {
+		t.Fatalf("output missing balance = %q", out)
+	}
+}
+
+func testAccountsUploadHistoryJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+
+	// Create a temp CSV file for upload.
+	csvPath := filepath.Join(dir, "history.csv")
+	if err := os.WriteFile(csvPath, []byte("date,balance\n2026-01-01,100\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, accountsUploadHistoryCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != "POST" {
+			t.Fatalf("method = %q, want POST", req.Method)
+		}
+		if !strings.Contains(req.URL.Path, "account-balance-history") {
+			t.Fatalf("path = %q, want account-balance-history", req.URL.Path)
+		}
+		return testutil.JSONResponse(`{"ok":true}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		accountsUploadHistoryCmd.Run(accountsUploadHistoryCmd, []string{"acc-1", csvPath})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.upload-history"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"uploaded"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testAccountsRecentBalancesJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsRecentBalancesCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAccountRecentBalances" {
+			t.Fatalf("operation = %q, want GetAccountRecentBalances", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"accounts":[{"id":"a1","displayName":"Checking","type":{"group":"asset"},"recentBalances":[1,2,3]}]}}`), nil
+	})
+
+	historyFrom = ""
+	_ = accountsRecentBalancesCmd.Flags().Set("from", "2026-05-01")
+	out := captureStdout(t, func() {
+		accountsRecentBalancesCmd.Run(accountsRecentBalancesCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.recent-balances"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"display_name":"Checking"`) {
+		t.Fatalf("output missing display name = %q", out)
+	}
+	if !strings.Contains(out, `"account_type_group":"asset"`) {
+		t.Fatalf("output missing account type group = %q", out)
+	}
+}
+
+func testAccountsSnapshotsJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsSnapshotsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetSnapshotsByAccountType" {
+			t.Fatalf("operation = %q, want GetSnapshotsByAccountType", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"snapshotsByAccountType":[{"accountType":"bank","month":"2026-05","balance":1}],"accountTypes":[{"name":"bank","group":"asset"}]}}`), nil
+	})
+
+	historyFrom = ""
+	timeframe = ""
+	_ = accountsSnapshotsCmd.Flags().Set("from", "2025-06-01")
+	_ = accountsSnapshotsCmd.Flags().Set("timeframe", "month")
+	out := captureStdout(t, func() {
+		accountsSnapshotsCmd.Run(accountsSnapshotsCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.snapshots"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"accountType":"bank"`) {
+		t.Fatalf("output missing account type = %q", out)
+	}
+}
+
+func testAccountsAggregateSnapshotsJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsAggregateSnapshotsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAggregateSnapshots" {
+			t.Fatalf("operation = %q, want GetAggregateSnapshots", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregateSnapshots":[{"date":"2026-05-01","balance":1}]}}`), nil
+	})
+
+	historyFrom = ""
+	historyTo = ""
+	accountType = ""
+	_ = accountsAggregateSnapshotsCmd.Flags().Set("from", "2025-01-01")
+	_ = accountsAggregateSnapshotsCmd.Flags().Set("to", "2026-05-31")
+	_ = accountsAggregateSnapshotsCmd.Flags().Set("type", "bank")
+	out := captureStdout(t, func() {
+		accountsAggregateSnapshotsCmd.Run(accountsAggregateSnapshotsCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"accounts.aggregate-snapshots"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"date":"2026-05-01"`) {
+		t.Fatalf("output missing date = %q", out)
+	}
+	if !strings.Contains(out, `"balance":1`) {
+		t.Fatalf("output missing balance = %q", out)
+	}
+}
+
+func testNetworthJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, networthCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetAggregateSnapshots" {
+			t.Fatalf("operation = %q, want GetAggregateSnapshots", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregateSnapshots":[{"date":"2026-05-01","balance":1}]}}`), nil
+	})
+
+	historyFrom = ""
+	historyTo = ""
+	accountType = ""
+	_ = networthCmd.Flags().Set("from", "2025-01-01")
+	_ = networthCmd.Flags().Set("to", "2026-05-31")
+	_ = networthCmd.Flags().Set("type", "bank")
+	out := captureStdout(t, func() {
+		networthCmd.Run(networthCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"networth"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"date":"2026-05-01"`) {
+		t.Fatalf("output missing date = %q", out)
+	}
+}

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/audit"
+)
+
+func TestAuditCmdRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range RootCmd.Commands() {
+		if cmd.Name() == "audit" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("audit command not registered on RootCmd")
+	}
+}
+
+func TestAuditCleanupSubcommandRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range auditCmd.Commands() {
+		if cmd.Name() == "cleanup" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("cleanup subcommand not registered on auditCmd")
+	}
+}
+
+func TestAuditCleanupFlagExists(t *testing.T) {
+	f := auditCleanupCmd.Flags().Lookup("older-than")
+	if f == nil {
+		t.Fatal("audit cleanup command missing --older-than flag")
+	}
+	if f.DefValue != "30" {
+		t.Fatalf("--older-than default = %q, want 30", f.DefValue)
+	}
+}
+
+func TestAuditCleanupInvalidDays(t *testing.T) {
+	oldJSONMode := jsonMode
+	oldProfile := profile
+	oldExitFunc := exitFunc
+	jsonMode = true
+	profile = "default"
+	exitFunc = func(int) {}
+	defer func() {
+		jsonMode = oldJSONMode
+		profile = oldProfile
+		exitFunc = oldExitFunc
+	}()
+
+	auditCleanupDays = 0
+
+	out := captureStdout(t, func() {
+		auditCleanupCmd.Run(auditCleanupCmd, nil)
+	})
+
+	var env struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(trimNewline(out)), &env); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; output=%q", err, out)
+	}
+	if env.OK {
+		t.Fatal("expected ok=false for zero days")
+	}
+	if env.Error.Code != "INVALID_ARGUMENTS" {
+		t.Fatalf("error code = %q, want INVALID_ARGUMENTS", env.Error.Code)
+	}
+}
+
+func TestAuditCleanupInvalidDaysPlainText(t *testing.T) {
+	oldJSONMode := jsonMode
+	oldExitFunc := exitFunc
+	jsonMode = false
+	var gotExitCode int
+	exitFunc = func(code int) { gotExitCode = code }
+	defer func() {
+		jsonMode = oldJSONMode
+		exitFunc = oldExitFunc
+	}()
+
+	auditCleanupDays = -5
+
+	// In non-JSON mode, handleError writes to stderr, so we just verify
+	// the exit code is correct (InvalidArguments = exit code 2).
+	auditCleanupCmd.Run(auditCleanupCmd, nil)
+
+	if gotExitCode != 2 {
+		t.Fatalf("exit code = %d, want 2 (InvalidArguments)", gotExitCode)
+	}
+}
+
+func TestAuditCleanupRemovesOldFiles(t *testing.T) {
+	// Create a temp audit directory with some old log files.
+	dir := t.TempDir()
+
+	oldDate := time.Now().AddDate(0, 0, -60).Format("2006-01-02")
+	oldFile := filepath.Join(dir, oldDate+".jsonl")
+	if err := os.WriteFile(oldFile, []byte(`{"command":"test"}`), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	recentDate := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
+	recentFile := filepath.Join(dir, recentDate+".jsonl")
+	if err := os.WriteFile(recentFile, []byte(`{"command":"test"}`), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Directly test audit.Logger.Cleanup against the temp directory.
+	logger := &audit.Logger{Dir: dir}
+	removed, err := logger.Cleanup(30)
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if removed != 1 {
+		t.Fatalf("Cleanup() removed = %d, want 1", removed)
+	}
+
+	// Old file should be gone, recent file should remain.
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Fatalf("old file still exists: %v", err)
+	}
+	if _, err := os.Stat(recentFile); err != nil {
+		t.Fatalf("recent file should still exist: %v", err)
+	}
+}
+
+func TestAuditCleanupNoDirectory(t *testing.T) {
+	logger := &audit.Logger{Dir: filepath.Join(t.TempDir(), "nonexistent")}
+	removed, err := logger.Cleanup(30)
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("Cleanup() removed = %d, want 0", removed)
+	}
+}
+
+func TestAuditCleanupSkipsNonJSONL(t *testing.T) {
+	dir := t.TempDir()
+
+	oldDate := time.Now().AddDate(0, 0, -60).Format("2006-01-02")
+	// Write a .txt file that looks like it could be an old log.
+	txtFile := filepath.Join(dir, oldDate+".txt")
+	if err := os.WriteFile(txtFile, []byte("not a log"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	logger := &audit.Logger{Dir: dir}
+	removed, err := logger.Cleanup(30)
+	if err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if removed != 0 {
+		t.Fatalf("Cleanup() removed = %d, want 0 (non-jsonl file should be skipped)", removed)
+	}
+
+	// Verify the file still exists.
+	if _, err := os.Stat(txtFile); err != nil {
+		t.Fatalf("txt file should still exist: %v", err)
+	}
+}

--- a/internal/cli/banner_test.go
+++ b/internal/cli/banner_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBannerNonEmpty(t *testing.T) {
+	if monarchBanner == "" {
+		t.Fatal("monarchBanner is empty")
+	}
+}
+
+func TestBannerContainsPlusSigns(t *testing.T) {
+	if !strings.Contains(monarchBanner, "+") {
+		t.Fatal("monarchBanner does not contain '+' characters")
+	}
+}
+
+func TestBannerLineCount(t *testing.T) {
+	lines := strings.Split(monarchBanner, "\n")
+	// The banner should have a reasonable number of lines (it's ASCII art).
+	if len(lines) < 10 {
+		t.Fatalf("monarchBanner has %d lines, want at least 10", len(lines))
+	}
+}
+
+func TestBannerUsedInVersionOutput(t *testing.T) {
+	// Verify that writeVersion includes the banner in plain text mode.
+	var buf bytes.Buffer
+	if err := writeVersion(&buf, "default", false, false, 0); err != nil {
+		t.Fatalf("writeVersion() error = %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, monarchBanner) {
+		t.Fatal("writeVersion() plain text output does not contain banner")
+	}
+}

--- a/internal/cli/budgets_test.go
+++ b/internal/cli/budgets_test.go
@@ -1,0 +1,289 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestBudgets(t *testing.T) {
+	t.Run("list", testBudgetsListJSON)
+	t.Run("list_api_error", testBudgetsListAPIError)
+	t.Run("list_invalid_month", testBudgetsListInvalidMonth)
+	t.Run("export", testBudgetsExportJSON)
+	t.Run("reset", testBudgetsResetJSON)
+	t.Run("reset_missing_month", testBudgetsResetMissingMonth)
+	t.Run("reset_invalid_month", testBudgetsResetInvalidMonth)
+	t.Run("flexible_set", testBudgetsFlexibleSetJSON)
+	t.Run("flex_rollover_set", testBudgetsFlexRolloverSetJSON)
+}
+
+func testBudgetsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, budgetsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetJointPlanningData" {
+			t.Fatalf("operation = %q, want GetJointPlanningData", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"budgetData":{"monthlyAmountsByCategory":[{"category":{"id":"cat-1","name":"Dining"},"monthlyAmounts":[{"month":"2026-06","plannedCashFlowAmount":300,"actualAmount":150.50}]},{"category":{"id":"cat-2","name":"Groceries"},"monthlyAmounts":[{"month":"2026-06","plannedCashFlowAmount":500,"actualAmount":425}]}]}}}`), nil
+	})
+
+	_ = budgetsListCmd.Flags().Set("month", "2026-06")
+	out := captureStdout(t, func() {
+		budgetsListCmd.Run(budgetsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"budgets.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"category_name":"Dining"`) {
+		t.Fatalf("output missing Dining category = %q", out)
+	}
+	if !strings.Contains(out, `"planned":300`) {
+		t.Fatalf("output missing planned amount = %q", out)
+	}
+	if !strings.Contains(out, `"actual":150.5`) {
+		t.Fatalf("output missing actual amount = %q", out)
+	}
+}
+
+func testBudgetsListAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, budgetsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	_ = budgetsListCmd.Flags().Set("month", "2026-06")
+	out := captureStdout(t, func() {
+		budgetsListCmd.Run(budgetsListCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}
+
+func testBudgetsListInvalidMonth(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, budgetsListCmd)
+	saveTestSession(t, sessionPath)
+
+	_ = budgetsListCmd.Flags().Set("month", "2026/06")
+	out := captureStdout(t, func() {
+		budgetsListCmd.Run(budgetsListCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "YYYY-MM") {
+		t.Fatalf("output = %q, want month format guidance", out)
+	}
+}
+
+func testBudgetsExportJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, budgetsExportCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		return testutil.JSONResponse(`{"data":{"budgetData":{"monthlyAmountsByCategory":[{"category":{"id":"cat-1","name":"Rent"},"monthlyAmounts":[{"month":"2026-06","plannedCashFlowAmount":1500,"actualAmount":1500}]}]}}}`), nil
+	})
+
+	_ = budgetsExportCmd.Flags().Set("month", "2026-06")
+	out := captureStdout(t, func() {
+		budgetsExportCmd.Run(budgetsExportCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"budgets.export"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"category_name":"Rent"`) {
+		t.Fatalf("output missing Rent category = %q", out)
+	}
+}
+
+func testBudgetsResetJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, budgetsResetCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "ResetBudget" {
+			t.Fatalf("operation = %q, want ResetBudget", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"resetBudget":{"ok":true}}}`), nil
+	})
+
+	monthStr = ""
+	_ = budgetsResetCmd.Flags().Set("month", "2026-06")
+	out := captureStdout(t, func() {
+		budgetsResetCmd.Run(budgetsResetCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"budgets.reset"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"budget reset"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testBudgetsResetMissingMonth(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, budgetsResetCmd)
+	saveTestSession(t, sessionPath)
+
+	monthStr = ""
+	out := captureStdout(t, func() {
+		budgetsResetCmd.Run(budgetsResetCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "--month is required") {
+		t.Fatalf("output = %q, want month required message", out)
+	}
+}
+
+func testBudgetsResetInvalidMonth(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, budgetsResetCmd)
+	saveTestSession(t, sessionPath)
+
+	monthStr = ""
+	_ = budgetsResetCmd.Flags().Set("month", "bad")
+	out := captureStdout(t, func() {
+		budgetsResetCmd.Run(budgetsResetCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "YYYY-MM") {
+		t.Fatalf("output = %q, want month format guidance", out)
+	}
+}
+
+func testBudgetsFlexibleSetJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, budgetsFlexibleSetCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "UpdateFlexibleBudget" {
+			t.Fatalf("operation = %q, want UpdateFlexibleBudget", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"updateOrCreateFlexBudgetItem":{"flexBudgetItem":{"month":6}}}}`), nil
+	})
+
+	monthStr = ""
+	budgetAmount = 0
+	_ = budgetsFlexibleSetCmd.Flags().Set("month", "2026-06")
+	_ = budgetsFlexibleSetCmd.Flags().Set("amount", "750.50")
+	out := captureStdout(t, func() {
+		budgetsFlexibleSetCmd.Run(budgetsFlexibleSetCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"budgets.flexible.set"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+}
+
+func testBudgetsFlexRolloverSetJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, budgetsFlexRolloverSetCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "UpdateFlexRolloverSettings" {
+			t.Fatalf("operation = %q, want UpdateFlexRolloverSettings", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"updateBudgetSettings":{"budgetRolloverPeriod":{"id":"period-1"}}}}`), nil
+	})
+
+	monthStr = ""
+	budgetAmount = 0
+	_ = budgetsFlexRolloverSetCmd.Flags().Set("month", "2026-06-01")
+	_ = budgetsFlexRolloverSetCmd.Flags().Set("amount", "1000")
+	out := captureStdout(t, func() {
+		budgetsFlexRolloverSetCmd.Run(budgetsFlexRolloverSetCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"budgets.flex-rollover.set"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+}

--- a/internal/cli/cashflow_test.go
+++ b/internal/cli/cashflow_test.go
@@ -1,0 +1,378 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestCashflow(t *testing.T) {
+	t.Run("summary", testCashflowSummaryWithDates)
+	t.Run("categories", testCashflowCategoriesJSON)
+	t.Run("merchants", testCashflowMerchantsJSON)
+	t.Run("spending", testCashflowSpendingJSON)
+	t.Run("list", testCashflowListJSON)
+	t.Run("trends", testCashflowTrendsJSON)
+	t.Run("trends_missing_from", testCashflowTrendsMissingFrom)
+	t.Run("trends_invalid_from", testCashflowTrendsInvalidFrom)
+	t.Run("trends_invalid_to", testCashflowTrendsInvalidTo)
+	t.Run("trends_invalid_group_by", testCashflowTrendsInvalidGroupBy)
+	t.Run("trends_invalid_period", testCashflowTrendsInvalidPeriod)
+}
+
+func testCashflowSummaryWithDates(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowSummaryCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetCashflowSummary" {
+			t.Fatalf("operation = %q, want GetCashflowSummary", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregates":[{"summary":{"sumIncome":8500,"sumExpense":6200,"savings":2300,"savingsRate":0.2706}}]}}`), nil
+	})
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowSummaryCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowSummaryCmd.Flags().Set("to", "2026-03-31")
+	out := captureStdout(t, func() {
+		cashflowSummaryCmd.Run(cashflowSummaryCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"cashflow.summary"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"income":8500`) {
+		t.Fatalf("output missing income = %q", out)
+	}
+	if !strings.Contains(out, `"expense":6200`) {
+		t.Fatalf("output missing expense = %q", out)
+	}
+	if !strings.Contains(out, `"savings_rate":0.2706`) {
+		t.Fatalf("output missing savings rate = %q", out)
+	}
+}
+
+func testCashflowCategoriesJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowCategoriesCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetCashflowCategories" {
+			t.Fatalf("operation = %q, want GetCashflowCategories", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregates":[{"groupBy":{"category":{"id":"cat-1","name":"Dining"}},"summary":{"sum":-450.50}},{"groupBy":{"category":{"id":"cat-2","name":"Groceries"}},"summary":{"sum":-320}}]}}`), nil
+	})
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowCategoriesCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowCategoriesCmd.Flags().Set("to", "2026-03-31")
+	out := captureStdout(t, func() {
+		cashflowCategoriesCmd.Run(cashflowCategoriesCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"cashflow.categories"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"name":"Dining"`) {
+		t.Fatalf("output missing Dining = %q", out)
+	}
+}
+
+func testCashflowMerchantsJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowMerchantsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetCashflowMerchants" {
+			t.Fatalf("operation = %q, want GetCashflowMerchants", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregates":[{"groupBy":{"merchant":{"id":"m-1","name":"Amazon"}},"summary":{"sumIncome":0,"sumExpense":-120.50}}]}}`), nil
+	})
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowMerchantsCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowMerchantsCmd.Flags().Set("to", "2026-03-31")
+	out := captureStdout(t, func() {
+		cashflowMerchantsCmd.Run(cashflowMerchantsCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"cashflow.merchants"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"name":"Amazon"`) {
+		t.Fatalf("output missing Amazon = %q", out)
+	}
+}
+
+func testCashflowSpendingJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowSpendingCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetCashflowCategories" {
+			t.Fatalf("operation = %q, want GetCashflowCategories", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregates":[{"groupBy":{"category":{"id":"cat-1","name":"Income"}},"summary":{"sum":5000}},{"groupBy":{"category":{"id":"cat-2","name":"Dining"}},"summary":{"sum":-200}}]}}`), nil
+	})
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowSpendingCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowSpendingCmd.Flags().Set("to", "2026-03-31")
+	out := captureStdout(t, func() {
+		cashflowSpendingCmd.Run(cashflowSpendingCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"cashflow.spending"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"total_income":5000`) {
+		t.Fatalf("output missing total income = %q", out)
+	}
+	if !strings.Contains(out, `"total_expenses":200`) {
+		t.Fatalf("output missing total expenses = %q", out)
+	}
+	if !strings.Contains(out, `"net":4800`) {
+		t.Fatalf("output missing net = %q", out)
+	}
+}
+
+func testCashflowListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransactionsList" {
+			t.Fatalf("operation = %q, want GetTransactionsList", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"allTransactions":{"results":[{"id":"tx-1","date":"2026-05-01","amount":5000,"merchant":{"name":"Payroll"},"category":{"name":"Income"},"account":{"id":"acc-1"},"notes":""},{"id":"tx-2","date":"2026-05-01","amount":-12.34,"merchant":{"name":"Cafe"},"category":{"name":"Dining"},"account":{"id":"acc-1"},"notes":""},{"id":"tx-3","date":"2026-05-02","amount":-50,"merchant":{"name":"Store"},"category":{"name":"Shopping"},"account":{"id":"acc-1"},"notes":""}],"totalCount":3}}}`), nil
+	})
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowListCmd.Flags().Set("from", "2026-05-01")
+	_ = cashflowListCmd.Flags().Set("to", "2026-05-02")
+	out := captureStdout(t, func() {
+		cashflowListCmd.Run(cashflowListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"cashflow.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+}
+
+func testCashflowTrendsJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregates":[{"groupBy":{"category":{"id":"cat-1"},"month":"2026-01"},"summary":{"sum":-500,"sumIncome":0,"sumExpense":500}},{"groupBy":{"category":{"id":"cat-2"},"month":"2026-02"},"summary":{"sum":-300,"sumIncome":0,"sumExpense":300}}]}}`), nil
+	})
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowTrendsCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowTrendsCmd.Flags().Set("to", "2026-03-31")
+	_ = cashflowTrendsCmd.Flags().Set("group-by", "category")
+	_ = cashflowTrendsCmd.Flags().Set("period", "month")
+	out := captureStdout(t, func() {
+		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"cashflow.trends"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"group_id":"cat-1"`) {
+		t.Fatalf("output missing group_id = %q", out)
+	}
+	if !strings.Contains(out, `"sum_income":0`) {
+		t.Fatalf("output missing sum_income = %q", out)
+	}
+}
+
+func testCashflowTrendsMissingFrom(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
+	saveTestSession(t, sessionPath)
+
+	cfStartDate = ""
+	cfEndDate = ""
+	out := captureStdout(t, func() {
+		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "--from and --to are required") {
+		t.Fatalf("output = %q, want from/to required message", out)
+	}
+}
+
+func testCashflowTrendsInvalidFrom(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
+	saveTestSession(t, sessionPath)
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowTrendsCmd.Flags().Set("from", "01-01-2026")
+	_ = cashflowTrendsCmd.Flags().Set("to", "2026-03-31")
+	out := captureStdout(t, func() {
+		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "YYYY-MM-DD") {
+		t.Fatalf("output = %q, want date format guidance", out)
+	}
+}
+
+func testCashflowTrendsInvalidTo(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
+	saveTestSession(t, sessionPath)
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowTrendsCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowTrendsCmd.Flags().Set("to", "bad-date")
+	out := captureStdout(t, func() {
+		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "YYYY-MM-DD") {
+		t.Fatalf("output = %q, want date format guidance", out)
+	}
+}
+
+func testCashflowTrendsInvalidGroupBy(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
+	saveTestSession(t, sessionPath)
+
+	cfStartDate = ""
+	cfEndDate = ""
+	_ = cashflowTrendsCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowTrendsCmd.Flags().Set("to", "2026-03-31")
+	_ = cashflowTrendsCmd.Flags().Set("group-by", "week")
+	out := captureStdout(t, func() {
+		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "group-by must be category or category-group") {
+		t.Fatalf("output = %q, want group-by guidance", out)
+	}
+}
+
+func testCashflowTrendsInvalidPeriod(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
+	saveTestSession(t, sessionPath)
+
+	cfStartDate = ""
+	cfEndDate = ""
+	cfTrendGroupBy = ""
+	cfTrendPeriod = ""
+	_ = cashflowTrendsCmd.Flags().Set("from", "2026-01-01")
+	_ = cashflowTrendsCmd.Flags().Set("to", "2026-03-31")
+	_ = cashflowTrendsCmd.Flags().Set("group-by", "category")
+	_ = cashflowTrendsCmd.Flags().Set("period", "week")
+	out := captureStdout(t, func() {
+		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "month, quarter, or year") {
+		t.Fatalf("output = %q, want period guidance", out)
+	}
+}

--- a/internal/cli/cashflow_test.go
+++ b/internal/cli/cashflow_test.go
@@ -272,6 +272,8 @@ func testCashflowTrendsMissingFrom(t *testing.T) {
 
 	cfStartDate = ""
 	cfEndDate = ""
+	cfTrendGroupBy = ""
+	cfTrendPeriod = ""
 	out := captureStdout(t, func() {
 		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
 	})

--- a/internal/cli/categories_test.go
+++ b/internal/cli/categories_test.go
@@ -1,0 +1,224 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestCategories(t *testing.T) {
+	t.Run("list", testCategoriesListWithGroups)
+	t.Run("groups", testCategoriesGroupsJSON)
+	t.Run("delete", testCategoriesDeleteJSON)
+	t.Run("delete_many", testCategoriesDeleteManyJSON)
+	t.Run("delete_many_missing_file", testCategoriesDeleteManyMissingFile)
+	t.Run("delete_many_file_not_found", testCategoriesDeleteManyFileNotFound)
+}
+
+func testCategoriesListWithGroups(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, categoriesListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetCategories" {
+			t.Fatalf("operation = %q, want GetCategories", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"categories":[
+			{"id":"cat-1","name":"Dining","order":1,"icon":"utensils","group":{"id":"grp-1","name":"Food & Drink","type":"expense"}},
+			{"id":"cat-2","name":"Income","order":2,"icon":"dollar","group":{"id":"grp-2","name":"Income","type":"income"}}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		categoriesListCmd.Run(categoriesListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"categories.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"name":"Dining"`) {
+		t.Fatalf("output missing Dining = %q", out)
+	}
+	if !strings.Contains(out, `"group_name":"Food`) {
+		t.Fatalf("output missing group name = %q", out)
+	}
+}
+
+func testCategoriesGroupsJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, categoriesGroupsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetCategoryGroups" {
+			t.Fatalf("operation = %q, want GetCategoryGroups", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"categoryGroups":[
+			{"id":"grp-1","name":"Food & Drink","type":"expense","categories":[{"id":"cat-1","name":"Dining"}]},
+			{"id":"grp-2","name":"Income","type":"income","categories":[]}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		categoriesGroupsCmd.Run(categoriesGroupsCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"categories.groups"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"name":"Food`) {
+		t.Fatalf("output missing group name = %q", out)
+	}
+	if !strings.Contains(out, `"type":"expense"`) {
+		t.Fatalf("output missing group type = %q", out)
+	}
+}
+
+func testCategoriesDeleteJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, categoriesDeleteCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "DeleteCategory" {
+			t.Fatalf("operation = %q, want DeleteCategory", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["id"] != "cat-old" {
+			t.Fatalf("variables id = %v, want cat-old", gqlReq.Variables["id"])
+		}
+		return testutil.JSONResponse(`{"data":{"deleteCategory":{"ok":true}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		categoriesDeleteCmd.Run(categoriesDeleteCmd, []string{"cat-old"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"categories.delete"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"deleted"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testCategoriesDeleteManyJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, categoriesDeleteManyCmd)
+	saveTestSession(t, sessionPath)
+
+	idsFile := filepath.Join(dir, "ids.txt")
+	if err := os.WriteFile(idsFile, []byte("cat-1\ncat-2\ncat-3\n"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "DeleteCategories" {
+			t.Fatalf("operation = %q, want DeleteCategories", gqlReq.OperationName)
+		}
+		ids := gqlReq.Variables["ids"].([]any)
+		if len(ids) != 3 {
+			t.Fatalf("variables ids count = %d, want 3", len(ids))
+		}
+		return testutil.JSONResponse(`{"data":{"deleteTransactionCategories":{"ok":true}}}`), nil
+	})
+
+	categoryFile = ""
+	_ = categoriesDeleteManyCmd.Flags().Set("file", idsFile)
+	out := captureStdout(t, func() {
+		categoriesDeleteManyCmd.Run(categoriesDeleteManyCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"categories.delete-many"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"categories deleted"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testCategoriesDeleteManyMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, categoriesDeleteManyCmd)
+	saveTestSession(t, sessionPath)
+
+	categoryFile = ""
+	out := captureStdout(t, func() {
+		categoriesDeleteManyCmd.Run(categoriesDeleteManyCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
+	}
+	if !strings.Contains(out, "--file is required") {
+		t.Fatalf("output = %q, want --file required message", out)
+	}
+}
+
+func testCategoriesDeleteManyFileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, categoriesDeleteManyCmd)
+	saveTestSession(t, sessionPath)
+
+	categoryFile = ""
+	_ = categoriesDeleteManyCmd.Flags().Set("file", filepath.Join(dir, "nonexistent.txt"))
+	out := captureStdout(t, func() {
+		categoriesDeleteManyCmd.Run(categoriesDeleteManyCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want file error; output=%q", out)
+	}
+	if !strings.Contains(out, "failed to open file") {
+		t.Fatalf("output = %q, want file open failure", out)
+	}
+}

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCompletionCmdRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range RootCmd.Commands() {
+		if cmd.Name() == "completion" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("completion command not registered on RootCmd")
+	}
+}
+
+func TestCompletionValidArgs(t *testing.T) {
+	expected := []string{"bash", "zsh", "fish", "powershell"}
+	for _, shell := range expected {
+		found := false
+		for _, arg := range completionCmd.ValidArgs {
+			if arg == shell {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("completion ValidArgs missing %q", shell)
+		}
+	}
+}
+
+func TestCompletionBash(t *testing.T) {
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	defer RootCmd.SetOut(nil)
+
+	err := completionCmd.RunE(completionCmd, []string{"bash"})
+	if err != nil {
+		t.Fatalf("completion bash error = %v", err)
+	}
+	got := buf.String()
+	if len(got) == 0 {
+		t.Fatal("completion bash produced no output")
+	}
+	if !strings.Contains(got, "bash") || (!strings.Contains(got, "complete") && !strings.Contains(got, "compgen")) {
+		t.Fatalf("completion bash output does not look like bash completion; got %d bytes", len(got))
+	}
+}
+
+func TestCompletionZsh(t *testing.T) {
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	defer RootCmd.SetOut(nil)
+
+	err := completionCmd.RunE(completionCmd, []string{"zsh"})
+	if err != nil {
+		t.Fatalf("completion zsh error = %v", err)
+	}
+	got := buf.String()
+	if len(got) == 0 {
+		t.Fatal("completion zsh produced no output")
+	}
+}
+
+func TestCompletionFish(t *testing.T) {
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	defer RootCmd.SetOut(nil)
+
+	err := completionCmd.RunE(completionCmd, []string{"fish"})
+	if err != nil {
+		t.Fatalf("completion fish error = %v", err)
+	}
+	got := buf.String()
+	if len(got) == 0 {
+		t.Fatal("completion fish produced no output")
+	}
+}
+
+func TestCompletionPowershell(t *testing.T) {
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	defer RootCmd.SetOut(nil)
+
+	err := completionCmd.RunE(completionCmd, []string{"powershell"})
+	if err != nil {
+		t.Fatalf("completion powershell error = %v", err)
+	}
+	got := buf.String()
+	if len(got) == 0 {
+		t.Fatal("completion powershell produced no output")
+	}
+}
+
+func TestCompletionInvalidShell(t *testing.T) {
+	var buf bytes.Buffer
+	RootCmd.SetOut(&buf)
+	defer RootCmd.SetOut(nil)
+
+	err := completionCmd.RunE(completionCmd, []string{"tcsh"})
+	if err == nil {
+		t.Fatal("completion tcsh should return an error")
+	}
+	if !strings.Contains(err.Error(), "unsupported shell") {
+		t.Fatalf("error = %q, want 'unsupported shell'", err.Error())
+	}
+}

--- a/internal/cli/credit_test.go
+++ b/internal/cli/credit_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestCredit(t *testing.T) {
+	t.Run("history", testCreditHistory)
+	t.Run("history_api_error", testCreditHistoryAPIError)
+}
+
+func testCreditHistory(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, creditHistoryCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return testutil.JSONResponse(`{"data":{"creditScoreSnapshots":[{"reportedDate":"2026-05-01","score":790,"user":{"id":"u-1"}}]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		creditHistoryCmd.Run(creditHistoryCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"credit.history"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"score":790`) {
+		t.Fatalf("output missing score = %q", out)
+	}
+}
+
+func testCreditHistoryAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, creditHistoryCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		creditHistoryCmd.Run(creditHistoryCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}

--- a/internal/cli/deps_test.go
+++ b/internal/cli/deps_test.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	clierrors "github.com/thedavidweng/monarchmoney-cli/internal/errors"
+	"github.com/thedavidweng/monarchmoney-cli/internal/output"
+)
+
+func TestWrapError(t *testing.T) {
+	t.Run("plain error", func(t *testing.T) {
+		plain := errors.New("something broke")
+		wrapped := wrapError(plain, "operation failed")
+		if wrapped.Code != clierrors.APIError {
+			t.Fatalf("wrapError() code = %q, want %q", wrapped.Code, clierrors.APIError)
+		}
+		if wrapped.Message != "operation failed" {
+			t.Fatalf("wrapError() message = %q, want %q", wrapped.Message, "operation failed")
+		}
+		if wrapped.Err != plain {
+			t.Fatalf("wrapError() err = %v, want %v", wrapped.Err, plain)
+		}
+	})
+
+	t.Run("structured error passthrough", func(t *testing.T) {
+		structured := clierrors.New(clierrors.NetworkUnreachable, "cannot reach API", clierrors.CatNetwork, true, nil)
+		wrapped := wrapError(structured, "ignored message")
+		if wrapped != structured {
+			t.Fatalf("wrapError() did not return same *errors.Error; got %v", wrapped)
+		}
+		if wrapped.Code != clierrors.NetworkUnreachable {
+			t.Fatalf("wrapError() code = %q, want %q", wrapped.Code, clierrors.NetworkUnreachable)
+		}
+	})
+
+	t.Run("nil error", func(t *testing.T) {
+		wrapped := wrapError(nil, "nil test")
+		if wrapped.Code != clierrors.APIError {
+			t.Fatalf("wrapError(nil) code = %q, want %q", wrapped.Code, clierrors.APIError)
+		}
+		if wrapped.Err != nil {
+			t.Fatalf("wrapError(nil) err = %v, want nil", wrapped.Err)
+		}
+	})
+}
+
+func TestMutateSuccess(t *testing.T) {
+	renderer := output.NewRenderer(nil, nil, false, false)
+	deps := CommandDeps{
+		Start:    time.Now(),
+		Renderer: renderer,
+	}
+
+	result, err := deps.Mutate("test.command", "res-123", func() (any, error) {
+		return map[string]string{"status": "ok"}, nil
+	}, "should not appear")
+
+	if err != nil {
+		t.Fatalf("Mutate() error = %v", err)
+	}
+	m, ok := result.(map[string]string)
+	if !ok {
+		t.Fatalf("Mutate() result type = %T", result)
+	}
+	if m["status"] != "ok" {
+		t.Fatalf("Mutate() result = %v", m)
+	}
+}
+
+func TestMutateFailure(t *testing.T) {
+	oldExitFunc := exitFunc
+	oldJSONMode := jsonMode
+	oldProfile := profile
+	exitFunc = func(int) {}
+	jsonMode = true
+	profile = "default"
+	defer func() {
+		exitFunc = oldExitFunc
+		jsonMode = oldJSONMode
+		profile = oldProfile
+	}()
+
+	renderer := output.NewRenderer(nil, nil, true, false)
+	deps := CommandDeps{
+		Start:    time.Now(),
+		Renderer: renderer,
+	}
+
+	result, err := deps.Mutate("test.fail", "res-456", func() (any, error) {
+		return nil, errors.New("boom")
+	}, "operation failed")
+
+	if err == nil {
+		t.Fatal("Mutate() expected error, got nil")
+	}
+	if result != nil {
+		t.Fatalf("Mutate() result = %v, want nil", result)
+	}
+}
+
+func TestMutateStructuredError(t *testing.T) {
+	oldExitFunc := exitFunc
+	oldJSONMode := jsonMode
+	oldProfile := profile
+	exitFunc = func(int) {}
+	jsonMode = true
+	profile = "default"
+	defer func() {
+		exitFunc = oldExitFunc
+		jsonMode = oldJSONMode
+		profile = oldProfile
+	}()
+
+	renderer := output.NewRenderer(nil, nil, true, false)
+	deps := CommandDeps{
+		Start:    time.Now(),
+		Renderer: renderer,
+	}
+
+	structuredErr := clierrors.New(clierrors.ValidationFailed, "bad input", clierrors.CatValidation, false, nil)
+	result, err := deps.Mutate("test.structured", "res-789", func() (any, error) {
+		return nil, structuredErr
+	}, "validation error")
+
+	if err != structuredErr {
+		t.Fatalf("Mutate() err = %v, want structuredErr", err)
+	}
+	if result != nil {
+		t.Fatalf("Mutate() result = %v, want nil", result)
+	}
+}
+
+func TestMutateAuditLog(t *testing.T) {
+	// Verify Mutate returns the result from fn without interacting with
+	// a real audit log (the Logger.Log call is best-effort and may fail
+	// silently if no audit dir exists).
+	renderer := output.NewRenderer(nil, nil, false, false)
+	deps := CommandDeps{
+		Start:    time.Now(),
+		Renderer: renderer,
+	}
+
+	type payload struct {
+		ID string `json:"id"`
+	}
+
+	got, err := deps.Mutate("test.audit", "res-100", func() (any, error) {
+		return &payload{ID: "abc"}, nil
+	}, "should not appear")
+
+	if err != nil {
+		t.Fatalf("Mutate() error = %v", err)
+	}
+	p, ok := got.(*payload)
+	if !ok {
+		t.Fatalf("Mutate() result type = %T", got)
+	}
+	if p.ID != "abc" {
+		t.Fatalf("Mutate() result.ID = %q", p.ID)
+	}
+}
+
+func TestMutateJSONOutput(t *testing.T) {
+	// Verify that when Mutate fails with jsonMode=true, the error envelope
+	// is rendered to stdout as JSON.
+	oldExitFunc := exitFunc
+	oldJSONMode := jsonMode
+	oldProfile := profile
+	exitFunc = func(int) {}
+	jsonMode = true
+	profile = "test-profile"
+	defer func() {
+		exitFunc = oldExitFunc
+		jsonMode = oldJSONMode
+		profile = oldProfile
+	}()
+
+	out := captureStdout(t, func() {
+		renderer := output.NewRenderer(nil, nil, true, false)
+		deps := CommandDeps{
+			Start:    time.Now(),
+			Renderer: renderer,
+		}
+
+		deps.Mutate("test.json", "res-json", func() (any, error) {
+			return nil, errors.New("fail")
+		}, "operation failed")
+	})
+
+	var env struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(trimNewline(out)), &env); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; output=%q", err, out)
+	}
+	if env.OK {
+		t.Fatal("expected ok=false in error envelope")
+	}
+}
+
+func trimNewline(s string) string {
+	for len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r') {
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/cli/deps_test.go
+++ b/internal/cli/deps_test.go
@@ -185,7 +185,7 @@ func TestMutateJSONOutput(t *testing.T) {
 			Renderer: renderer,
 		}
 
-		deps.Mutate("test.json", "res-json", func() (any, error) {
+		_, _ = deps.Mutate("test.json", "res-json", func() (any, error) {
 			return nil, errors.New("fail")
 		}, "operation failed")
 	})

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestDoctorCmdRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range RootCmd.Commands() {
+		if cmd.Name() == "doctor" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("doctor command not registered on RootCmd")
+	}
+}
+
+func TestDoctorPlainText(t *testing.T) {
+	out := captureStdout(t, func() {
+		doctorCmd.Run(doctorCmd, nil)
+	})
+
+	if !strings.Contains(out, "Monarch Money CLI Doctor") {
+		t.Fatalf("output = %q, want header", out)
+	}
+	if !strings.Contains(out, "Version:") {
+		t.Fatalf("output = %q, want Version line", out)
+	}
+	if !strings.Contains(out, "OS/Arch:") {
+		t.Fatalf("output = %q, want OS/Arch line", out)
+	}
+	if !strings.Contains(out, "Config Path:") {
+		t.Fatalf("output = %q, want Config Path line", out)
+	}
+	if !strings.Contains(out, "Session Path:") {
+		t.Fatalf("output = %q, want Session Path line", out)
+	}
+}
+
+func TestDoctorJSON(t *testing.T) {
+	oldJSONMode := jsonMode
+	oldProfile := profile
+	jsonMode = true
+	profile = "default"
+	defer func() {
+		jsonMode = oldJSONMode
+		profile = oldProfile
+	}()
+
+	out := captureStdout(t, func() {
+		doctorCmd.Run(doctorCmd, nil)
+	})
+
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Version string `json:"version"`
+			OS      string `json:"os"`
+			Arch    string `json:"arch"`
+			Config  struct {
+				Path   string `json:"path"`
+				Exists bool   `json:"exists"`
+			} `json:"config"`
+			Session struct {
+				Path   string `json:"path"`
+				Exists bool   `json:"exists"`
+			} `json:"session"`
+		} `json:"data"`
+		Meta struct {
+			Command string `json:"command"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal([]byte(trimNewline(out)), &env); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v; output=%q", err, out)
+	}
+	if !env.OK {
+		t.Fatal("expected ok=true")
+	}
+	if env.Data.OS == "" {
+		t.Fatal("expected OS to be populated")
+	}
+	if env.Data.Arch == "" {
+		t.Fatal("expected Arch to be populated")
+	}
+	if env.Meta.Command != "doctor" {
+		t.Fatalf("meta.command = %q, want doctor", env.Meta.Command)
+	}
+}
+
+func TestDoctorConnectFlag(t *testing.T) {
+	// Verify that --connect flag exists and is accepted.
+	f := doctorCmd.Flags().Lookup("connect")
+	if f == nil {
+		t.Fatal("doctor command missing --connect flag")
+	}
+	if f.DefValue != "false" {
+		t.Fatalf("--connect default = %q, want false", f.DefValue)
+	}
+}
+
+func TestDoctorConnectNotShownWithoutFlag(t *testing.T) {
+	out := captureStdout(t, func() {
+		doctorCmd.Run(doctorCmd, nil)
+	})
+
+	// Without --connect, the "API Connected:" line should not appear.
+	if strings.Contains(out, "API Connected:") {
+		t.Fatalf("output should not contain 'API Connected:' without --connect flag; got %q", out)
+	}
+}

--- a/internal/cli/goals_test.go
+++ b/internal/cli/goals_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestGoals(t *testing.T) {
+	t.Run("list", testGoalsListJSON)
+	t.Run("list_api_error", testGoalsListAPIError)
+}
+
+func testGoalsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, goalsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Web_GoalsV2" {
+			t.Fatalf("operation = %q, want Web_GoalsV2", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"goalsV2":[{"id":"goal-1","name":"Vacation"},{"id":"goal-2","name":"Emergency Fund"}]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		goalsListCmd.Run(goalsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"goals.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"Vacation"`) {
+		t.Fatalf("output missing Vacation = %q", out)
+	}
+	if !strings.Contains(out, `"Emergency Fund"`) {
+		t.Fatalf("output missing Emergency Fund = %q", out)
+	}
+}
+
+func testGoalsListAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, goalsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		goalsListCmd.Run(goalsListCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}

--- a/internal/cli/institutions_test.go
+++ b/internal/cli/institutions_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestInstitutions(t *testing.T) {
+	t.Run("list", testInstitutionsListJSON)
+	t.Run("list_dedup", testInstitutionsListDedup)
+	t.Run("list_api_error", testInstitutionsListAPIError)
+}
+
+func testInstitutionsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, institutionsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetInstitutionSettings" {
+			t.Fatalf("operation = %q, want GetInstitutionSettings", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"credentials":[
+			{"id":"cred-1","updateRequired":false,"disconnectedFromDataProviderAt":null,"dataProvider":"plaid","institution":{"id":"inst-1","plaidInstitutionId":"ins_1","name":"Chase","status":"active"}},
+			{"id":"cred-2","updateRequired":false,"disconnectedFromDataProviderAt":null,"dataProvider":"plaid","institution":{"id":"inst-2","plaidInstitutionId":"ins_2","name":"Wells Fargo","status":"active"}}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		institutionsListCmd.Run(institutionsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"institutions.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"name":"Chase"`) {
+		t.Fatalf("output missing Chase = %q", out)
+	}
+	if !strings.Contains(out, `"name":"Wells Fargo"`) {
+		t.Fatalf("output missing Wells Fargo = %q", out)
+	}
+}
+
+func testInstitutionsListDedup(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, institutionsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		// Two credentials for the same institution
+		return testutil.JSONResponse(`{"data":{"credentials":[
+			{"id":"cred-1","updateRequired":false,"disconnectedFromDataProviderAt":null,"dataProvider":"plaid","institution":{"id":"inst-1","plaidInstitutionId":"ins_1","name":"Chase","status":"active"}},
+			{"id":"cred-2","updateRequired":false,"disconnectedFromDataProviderAt":null,"dataProvider":"plaid","institution":{"id":"inst-1","plaidInstitutionId":"ins_1","name":"Chase","status":"active"}}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		institutionsListCmd.Run(institutionsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	// Should only appear once after dedup
+	count := strings.Count(out, `"name":"Chase"`)
+	if count != 1 {
+		t.Fatalf("Chase appeared %d times, want 1 (dedup); output=%q", count, out)
+	}
+}
+
+func testInstitutionsListAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, institutionsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		institutionsListCmd.Run(institutionsListCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}

--- a/internal/cli/investments_test.go
+++ b/internal/cli/investments_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestInvestments(t *testing.T) {
+	t.Run("portfolio", testInvestmentsPortfolio)
+	t.Run("portfolio_api_error", testInvestmentsPortfolioAPIError)
+	t.Run("performance", testInvestmentsPerformance)
+}
+
+func testInvestmentsPortfolio(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, investmentsPortfolioCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return testutil.JSONResponse(`{"data":{"portfolio":{"performance":{"totalValue":1000,"totalChangePercent":0.12,"totalChangeDollars":120},"aggregateHoldings":{"edges":[{"node":{"id":"node-1","quantity":2,"basis":400,"totalValue":1000,"security":{"id":"sec-1","ticker":"ABC","name":"ABC Fund","currentPrice":500},"holdings":[]}}]}}}}`), nil
+	})
+
+	investmentFrom = ""
+	investmentTo = ""
+	investmentAccountIDs = nil
+	_ = investmentsPortfolioCmd.Flags().Set("from", "2026-01-01")
+	_ = investmentsPortfolioCmd.Flags().Set("to", "2026-05-01")
+	_ = investmentsPortfolioCmd.Flags().Set("account-id", "acc-1")
+	out := captureStdout(t, func() {
+		investmentsPortfolioCmd.Run(investmentsPortfolioCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"investments.portfolio"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"total_value":1000`) {
+		t.Fatalf("output missing total_value = %q", out)
+	}
+	if !strings.Contains(out, `"ticker":"ABC"`) {
+		t.Fatalf("output missing ticker = %q", out)
+	}
+}
+
+func testInvestmentsPortfolioAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, investmentsPortfolioCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		investmentsPortfolioCmd.Run(investmentsPortfolioCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}
+
+func testInvestmentsPerformance(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, investmentsPerformanceCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return testutil.JSONResponse(`{"data":{"securityHistoricalPerformance":[{"security":{"id":"sec-1","ticker":"ABC","name":"ABC Fund"},"historicalChart":[{"date":"2026-01-01","returnPercent":0.1}]}]}}`), nil
+	})
+
+	investmentSecurityIDs = nil
+	investmentFrom = ""
+	investmentTo = ""
+	investmentIncludeValues = false
+	_ = investmentsPerformanceCmd.Flags().Set("security-id", "sec-1")
+	_ = investmentsPerformanceCmd.Flags().Set("from", "2026-01-01")
+	_ = investmentsPerformanceCmd.Flags().Set("to", "2026-05-01")
+	out := captureStdout(t, func() {
+		investmentsPerformanceCmd.Run(investmentsPerformanceCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"investments.performance"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"ticker":"ABC"`) {
+		t.Fatalf("output missing ticker = %q", out)
+	}
+}

--- a/internal/cli/metadata_test.go
+++ b/internal/cli/metadata_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestEnvelopeWithWarningsMultiple(t *testing.T) {
+	originalProfile := profile
+	profile = "test-prof"
+	defer func() { profile = originalProfile }()
+
+	warnings := []string{
+		"uses legacy field",
+		"deprecated endpoint",
+	}
+	env := envelopeWithWarnings("accounts.list", map[string]int{"count": 5}, time.Now(), warnings...)
+
+	if len(env.Meta.Warnings) != 2 {
+		t.Fatalf("warnings count = %d, want 2", len(env.Meta.Warnings))
+	}
+	if env.Meta.Warnings[0] != "uses legacy field" {
+		t.Fatalf("warnings[0] = %q", env.Meta.Warnings[0])
+	}
+	if env.Meta.Warnings[1] != "deprecated endpoint" {
+		t.Fatalf("warnings[1] = %q", env.Meta.Warnings[1])
+	}
+	if env.Meta.Command != "accounts.list" {
+		t.Fatalf("command = %q, want accounts.list", env.Meta.Command)
+	}
+	if env.Meta.Profile != "test-prof" {
+		t.Fatalf("profile = %q, want test-prof", env.Meta.Profile)
+	}
+}
+
+func TestEnvelopeWithWarningsNone(t *testing.T) {
+	originalProfile := profile
+	profile = "default"
+	defer func() { profile = originalProfile }()
+
+	env := envelopeWithWarnings("test.cmd", nil, time.Now())
+	if env.Meta.Warnings != nil {
+		t.Fatalf("warnings = %v, want nil when no warnings provided", env.Meta.Warnings)
+	}
+	if !env.OK {
+		t.Fatal("expected ok=true")
+	}
+}
+
+func TestEnvelopeWithWarningsJSON(t *testing.T) {
+	originalProfile := profile
+	profile = "default"
+	defer func() { profile = originalProfile }()
+
+	env := envelopeWithWarnings("tx.search", map[string]string{"q": "Amazon"}, time.Now(), "field renamed")
+
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	meta, ok := decoded["meta"].(map[string]any)
+	if !ok {
+		t.Fatalf("meta missing from JSON: %v", decoded)
+	}
+	w, ok := meta["warnings"].([]any)
+	if !ok || len(w) != 1 {
+		t.Fatalf("meta.warnings = %v, want 1-element array", meta["warnings"])
+	}
+}

--- a/internal/cli/official_api_test.go
+++ b/internal/cli/official_api_test.go
@@ -141,6 +141,7 @@ func TestInvestmentsPerformanceRequiresSecurityID(t *testing.T) {
 	exitCode := withReadCommandTestDefaults(t, sessionPath, investmentsPerformanceCmd)
 	saveTestSession(t, sessionPath)
 
+	investmentSecurityIDs = nil
 	out := captureStdout(t, func() {
 		investmentsPerformanceCmd.Run(investmentsPerformanceCmd, nil)
 	})

--- a/internal/cli/official_api_test.go
+++ b/internal/cli/official_api_test.go
@@ -83,58 +83,6 @@ func TestAccountsBalanceAtJSON(t *testing.T) {
 	}
 }
 
-func TestCashflowTrendsRejectsInvalidPeriod(t *testing.T) {
-	dir := t.TempDir()
-	sessionPath := filepath.Join(dir, "session.json")
-	exitCode := withReadCommandTestDefaults(t, sessionPath, cashflowTrendsCmd)
-	saveTestSession(t, sessionPath)
-
-	_ = cashflowTrendsCmd.Flags().Set("from", "2026-01-01")
-	_ = cashflowTrendsCmd.Flags().Set("to", "2026-03-31")
-	_ = cashflowTrendsCmd.Flags().Set("period", "week")
-	out := captureStdout(t, func() {
-		cashflowTrendsCmd.Run(cashflowTrendsCmd, nil)
-	})
-
-	if *exitCode == 0 {
-		t.Fatalf("exitCode = 0, want validation failure; output=%q", out)
-	}
-	if !strings.Contains(out, "month, quarter, or year") {
-		t.Fatalf("output = %q, want period guidance", out)
-	}
-}
-
-func TestGoalsListJSON(t *testing.T) {
-	dir := t.TempDir()
-	sessionPath := filepath.Join(dir, "session.json")
-	exitCode := withReadCommandTestDefaults(t, sessionPath, goalsListCmd)
-	saveTestSession(t, sessionPath)
-
-	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		var gqlReq struct {
-			OperationName string `json:"operationName"`
-		}
-		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
-			t.Fatalf("Decode request error = %v", err)
-		}
-		if gqlReq.OperationName != "Web_GoalsV2" {
-			t.Fatalf("operation = %q, want goals", gqlReq.OperationName)
-		}
-		return testutil.JSONResponse(`{"data":{"goalsV2":[{"id":"goal-1","name":"Vacation"}]}}`), nil
-	})
-
-	out := captureStdout(t, func() {
-		goalsListCmd.Run(goalsListCmd, nil)
-	})
-
-	if *exitCode != 0 {
-		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
-	}
-	if !strings.Contains(out, `"command":"goals.list"`) || !strings.Contains(out, `"Vacation"`) {
-		t.Fatalf("output = %q", out)
-	}
-}
-
 func TestInvestmentsPerformanceRequiresSecurityID(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.json")
@@ -151,47 +99,6 @@ func TestInvestmentsPerformanceRequiresSecurityID(t *testing.T) {
 	}
 	if !strings.Contains(out, "--security-id is required") {
 		t.Fatalf("output = %q, want security guidance", out)
-	}
-}
-
-func TestAccountsListJSON(t *testing.T) {
-	dir := t.TempDir()
-	sessionPath := filepath.Join(dir, "session.json")
-	exitCode := withReadCommandTestDefaults(t, sessionPath, accountsListCmd)
-	saveTestSession(t, sessionPath)
-
-	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		var gqlReq struct {
-			OperationName string `json:"operationName"`
-		}
-		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
-			t.Fatalf("Decode request error = %v", err)
-		}
-		if gqlReq.OperationName != "GetAccounts" {
-			t.Fatalf("operation = %q, want GetAccounts", gqlReq.OperationName)
-		}
-		return testutil.JSONResponse(`{"data":{"accounts":[
-			{"id":"acc-1","displayName":"Checking","type":{"name":"cash","display":"Cash"},"subtype":{"name":"checking","display":"Checking"},"displayBalance":1250.50,"currentBalance":1250.50,"updatedAt":"2026-05-09","isHidden":false,"isAsset":true,"mask":"1234","isManual":false},
-			{"id":"acc-2","displayName":"Credit Card","type":{"name":"credit","display":"Credit"},"subtype":{"name":"credit_card","display":"Credit Card"},"displayBalance":-450.00,"currentBalance":-450.00,"updatedAt":"2026-05-08","isHidden":false,"isAsset":false,"mask":"5678","isManual":false},
-			{"id":"acc-3","displayName":"Savings","type":{"name":"cash","display":"Cash"},"subtype":{"name":"savings","display":"Savings"},"displayBalance":0.00,"currentBalance":0.00,"updatedAt":"2026-05-07","isHidden":false,"isAsset":true,"mask":"9012","isManual":true}
-		],"householdPreferences":{"id":"pref-1","accountGroupOrder":["acc-1","acc-2","acc-3"]}}}`), nil
-	})
-
-	out := captureStdout(t, func() {
-		accountsListCmd.Run(accountsListCmd, nil)
-	})
-
-	if *exitCode != 0 {
-		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
-	}
-	if !strings.Contains(out, `"command":"accounts.list"`) || !strings.Contains(out, `"display_name":"Checking"`) {
-		t.Fatalf("output = %q", out)
-	}
-	if !strings.Contains(out, `"display_balance":-450`) {
-		t.Fatalf("output missing negative balance = %q", out)
-	}
-	if !strings.Contains(out, `"display_balance":0`) {
-		t.Fatalf("output missing zero balance = %q", out)
 	}
 }
 

--- a/internal/cli/recurring_test.go
+++ b/internal/cli/recurring_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestRecurring(t *testing.T) {
+	t.Run("list", testRecurringListJSON)
+	t.Run("update", testRecurringUpdateJSON)
+}
+
+func testRecurringListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, recurringListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Web_GetUpcomingRecurringTransactionItems" {
+			t.Fatalf("operation = %q, want Web_GetUpcomingRecurringTransactionItems", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"recurringTransactionItems":[
+			{"stream":{"id":"rec-1","frequency":"monthly","amount":15.99,"isApproximate":false,"merchant":{"id":"m-1","name":"Netflix","logoUrl":""}},"date":"2026-06-15","isPast":false,"transactionId":"","amount":15.99,"amountDiff":0,"category":{"id":"cat-1","name":"Entertainment"},"account":{"id":"acc-1","displayName":"Checking"}},
+			{"stream":{"id":"rec-2","frequency":"weekly","amount":50,"isApproximate":false,"merchant":{"id":"m-2","name":"Gym","logoUrl":""}},"date":"2026-06-16","isPast":false,"transactionId":"","amount":50,"amountDiff":0,"category":{"id":"cat-2","name":"Health"},"account":{"id":"acc-1","displayName":"Checking"}}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		recurringListCmd.Run(recurringListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"recurring.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"merchant":"Netflix"`) {
+		t.Fatalf("output missing Netflix = %q", out)
+	}
+	if !strings.Contains(out, `"frequency":"monthly"`) {
+		t.Fatalf("output missing frequency = %q", out)
+	}
+	if !strings.Contains(out, `"amount":15.99`) {
+		t.Fatalf("output missing amount = %q", out)
+	}
+}
+
+func testRecurringUpdateJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, recurringUpdateCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "UpdateRecurringTransaction" {
+			t.Fatalf("operation = %q, want UpdateRecurringTransaction", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["id"] != "rec-1" {
+			t.Fatalf("variables id = %v, want rec-1", gqlReq.Variables["id"])
+		}
+		if gqlReq.Variables["amount"] != float64(19.99) {
+			t.Fatalf("variables amount = %v, want 19.99", gqlReq.Variables["amount"])
+		}
+		return testutil.JSONResponse(`{"data":{"updateRecurringTransaction":{"recurringTransaction":{"id":"rec-1","amount":19.99}}}}`), nil
+	})
+
+	recurringAmount = 0
+	_ = recurringUpdateCmd.Flags().Set("amount", "19.99")
+	out := captureStdout(t, func() {
+		recurringUpdateCmd.Run(recurringUpdateCmd, []string{"rec-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"recurring.update"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, "rec-1") {
+		t.Fatalf("output missing ID = %q", out)
+	}
+}

--- a/internal/cli/rules_test.go
+++ b/internal/cli/rules_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestRules(t *testing.T) {
+	t.Run("list", testRulesListJSON)
+	t.Run("update", testRulesUpdateJSON)
+	t.Run("delete", testRulesDeleteJSON)
+}
+
+func testRulesListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, rulesListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransactionRules" {
+			t.Fatalf("operation = %q, want GetTransactionRules", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"transactionRules":[
+			{"id":"rule-1","order":1,"merchantCriteriaUseOriginalStatement":false,"merchantCriteria":[],"merchantNameCriteria":[{"operator":"contains","value":"Uber"}],"amountCriteria":null,"categoryIds":[],"accountIds":[],"setCategoryAction":{"id":"cat-1","name":"Transportation"},"setMerchantAction":null,"addTagsAction":[],"setHideFromReportsAction":null,"reviewStatusAction":null,"recentApplicationCount":5,"lastAppliedAt":"2026-05-01"},
+			{"id":"rule-2","order":2,"merchantCriteriaUseOriginalStatement":false,"merchantCriteria":[],"merchantNameCriteria":[{"operator":"eq","value":"Netflix"}],"amountCriteria":{"operator":"eq","isExpense":true,"value":15.99},"categoryIds":["cat-2"],"accountIds":[],"setCategoryAction":{"id":"cat-2","name":"Entertainment"},"setMerchantAction":null,"addTagsAction":[],"setHideFromReportsAction":null,"reviewStatusAction":null,"recentApplicationCount":12,"lastAppliedAt":"2026-05-15"}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		rulesListCmd.Run(rulesListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"rules.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"set_category_action"`) {
+		t.Fatalf("output missing set_category_action = %q", out)
+	}
+	if !strings.Contains(out, "Transportation") {
+		t.Fatalf("output missing Transportation = %q", out)
+	}
+	if !strings.Contains(out, "Uber") {
+		t.Fatalf("output missing Uber = %q", out)
+	}
+	if !strings.Contains(out, "contains") {
+		t.Fatalf("output missing operator = %q", out)
+	}
+}
+
+func testRulesUpdateJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, rulesUpdateCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Common_UpdateTransactionRuleMutationV2" {
+			t.Fatalf("operation = %q, want Common_UpdateTransactionRuleMutationV2", gqlReq.OperationName)
+		}
+		input := gqlReq.Variables["input"].(map[string]any)
+		if input["id"] != "rule-1" {
+			t.Fatalf("input id = %v, want rule-1", input["id"])
+		}
+		return testutil.JSONResponse(`{"data":{"updateTransactionRuleV2":{}}}`), nil
+	})
+
+	ruleMerchantOperator = ""
+	ruleMerchantValue = ""
+	ruleSetCategoryID = ""
+	_ = rulesUpdateCmd.Flags().Set("merchant-operator", "contains")
+	_ = rulesUpdateCmd.Flags().Set("merchant-value", "Lyft")
+	_ = rulesUpdateCmd.Flags().Set("set-category-id", "cat-transport")
+	out := captureStdout(t, func() {
+		rulesUpdateCmd.Run(rulesUpdateCmd, []string{"rule-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"rules.update"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"updated"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testRulesDeleteJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, rulesDeleteCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Common_DeleteTransactionRule" {
+			t.Fatalf("operation = %q, want Common_DeleteTransactionRule", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["id"] != "rule-old" {
+			t.Fatalf("variables id = %v, want rule-old", gqlReq.Variables["id"])
+		}
+		return testutil.JSONResponse(`{"data":{"deleteTransactionRule":{"deleted":true,"errors":null}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		rulesDeleteCmd.Run(rulesDeleteCmd, []string{"rule-old"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"rules.delete"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"deleted"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}

--- a/internal/cli/subscription_test.go
+++ b/internal/cli/subscription_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestSubscription(t *testing.T) {
+	t.Run("show", testSubscriptionShowJSON)
+	t.Run("show_api_error", testSubscriptionShowAPIError)
+}
+
+func testSubscriptionShowJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, subscriptionShowCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetSubscriptionDetails" {
+			t.Fatalf("operation = %q, want GetSubscriptionDetails", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"subscription":{"id":"sub-1","paymentSource":"Visa ending 1234","referralCode":"ABC123","isOnFreeTrial":false,"hasPremiumEntitlement":true}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		subscriptionShowCmd.Run(subscriptionShowCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"subscription.show"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"payment_source":"Visa ending 1234"`) {
+		t.Fatalf("output missing payment source = %q", out)
+	}
+	if !strings.Contains(out, `"referral_code":"ABC123"`) {
+		t.Fatalf("output missing referral code = %q", out)
+	}
+	if !strings.Contains(out, `"has_premium_entitlement":true`) {
+		t.Fatalf("output missing premium entitlement = %q", out)
+	}
+	// Verify the legacy GraphQL warning is present
+	if !strings.Contains(out, "uses legacy Monarch GraphQL root field") {
+		t.Fatalf("output missing legacy warning = %q", out)
+	}
+}
+
+func testSubscriptionShowAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, subscriptionShowCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		subscriptionShowCmd.Run(subscriptionShowCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestTags(t *testing.T) {
+	t.Run("list", testTagsListJSON)
+	t.Run("create", testTagsCreateJSON)
+}
+
+func testTagsListJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, tagsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTags" {
+			t.Fatalf("operation = %q, want GetTags", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"householdTransactionTags":[
+			{"id":"tag-1","name":"reimbursable","color":"#ff0000"},
+			{"id":"tag-2","name":"tax-deductible","color":"#00ff00"}
+		]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		tagsListCmd.Run(tagsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"tags.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"name":"reimbursable"`) {
+		t.Fatalf("output missing reimbursable = %q", out)
+	}
+	if !strings.Contains(out, `"color":"#ff0000"`) {
+		t.Fatalf("output missing color = %q", out)
+	}
+}
+
+func testTagsCreateJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, tagsCreateCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "CreateTag" {
+			t.Fatalf("operation = %q, want CreateTag", gqlReq.OperationName)
+		}
+		if gqlReq.Variables["name"] != "vacation" {
+			t.Fatalf("variables name = %v, want vacation", gqlReq.Variables["name"])
+		}
+		if gqlReq.Variables["color"] != "#0000ff" {
+			t.Fatalf("variables color = %v, want #0000ff", gqlReq.Variables["color"])
+		}
+		return testutil.JSONResponse(`{"data":{"createHouseholdTransactionTag":{"tag":{"id":"tag-new","name":"vacation","color":"#0000ff"}}}}`), nil
+	})
+
+	tagName = ""
+	tagColor = ""
+	_ = tagsCreateCmd.Flags().Set("name", "vacation")
+	_ = tagsCreateCmd.Flags().Set("color", "#0000ff")
+	out := captureStdout(t, func() {
+		tagsCreateCmd.Run(tagsCreateCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"tags.create"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, "tag-new") {
+		t.Fatalf("output missing tag ID = %q", out)
+	}
+	if !strings.Contains(out, "vacation") {
+		t.Fatalf("output missing tag name = %q", out)
+	}
+}

--- a/internal/cli/transactions_test.go
+++ b/internal/cli/transactions_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -574,8 +575,11 @@ func testTransactionsAttachmentsUpload(t *testing.T) {
 	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsAttachmentsUploadCmd)
 	saveTestSession(t, sessionPath)
 
+	tmpFile := filepath.Join(dir, "receipt.pdf")
+	_ = os.WriteFile(tmpFile, []byte("pdf"), 0600)
+
 	out := captureStdout(t, func() {
-		transactionsAttachmentsUploadCmd.Run(transactionsAttachmentsUploadCmd, []string{"tx-1", "/tmp/file.pdf"})
+		transactionsAttachmentsUploadCmd.Run(transactionsAttachmentsUploadCmd, []string{"tx-1", tmpFile})
 	})
 
 	if *exitCode == 0 {

--- a/internal/cli/transactions_test.go
+++ b/internal/cli/transactions_test.go
@@ -1,0 +1,626 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestTransactions(t *testing.T) {
+	t.Run("list", testTransactionsList)
+	t.Run("list_api_error", testTransactionsListAPIError)
+	t.Run("show_missing_args", testTransactionsShowMissingArgs)
+	t.Run("show", testTransactionsShow)
+	t.Run("create", testTransactionsCreate)
+	t.Run("update", testTransactionsUpdate)
+	t.Run("delete", testTransactionsDelete)
+	t.Run("summary", testTransactionsSummary)
+	t.Run("export_json", testTransactionsExportJSON)
+	t.Run("tags_set", testTransactionsTagsSet)
+	t.Run("tags_clear", testTransactionsTagsClear)
+	t.Run("tags_add", testTransactionsTagsAdd)
+	t.Run("splits", testTransactionsSplits)
+	t.Run("bulk_categorize", testTransactionsBulkCategorize)
+	t.Run("attachments_list", testTransactionsAttachmentsList)
+	t.Run("attachments_upload", testTransactionsAttachmentsUpload)
+	t.Run("search", testTransactionsSearch)
+}
+
+func testTransactionsList(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransactionsList" {
+			t.Fatalf("operation = %q, want GetTransactionsList", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"allTransactions":{"results":[{"id":"tx-1","date":"2026-05-08","amount":-20,"merchant":{"name":"Store"},"category":{"name":"Food"},"notes":"lunch","tags":[],"goal":{"id":"","name":""},"account":{"id":"acc-1","displayName":"Checking","order":0,"type":{"group":"depository"}},"ownedByUser":{"displayName":"Test User"}}],"totalCount":1}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsListCmd.Run(transactionsListCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"total":1`) {
+		t.Fatalf("output missing total = %q", out)
+	}
+	if !strings.Contains(out, "Store") {
+		t.Fatalf("output missing merchant = %q", out)
+	}
+}
+
+func testTransactionsListAPIError(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsListCmd.Run(transactionsListCmd, nil)
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}
+
+func testTransactionsShowMissingArgs(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsShowCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsShowCmd.Run(transactionsShowCmd, []string{"tx-1"})
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want API failure; output=%q", out)
+	}
+	if !strings.Contains(out, `"API_ERROR"`) {
+		t.Fatalf("output = %q, want API_ERROR", out)
+	}
+}
+
+func testTransactionsShow(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsShowCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransaction" {
+			t.Fatalf("operation = %q, want GetTransaction", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"getTransaction":{"id":"tx-1","date":"2026-05-08","amount":-20,"merchant":{"name":"Store"},"category":{"name":"Food"},"notes":"lunch","account":{"id":"acc-1","displayName":"Checking"},"tags":[]}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsShowCmd.Run(transactionsShowCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.show"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"id":"tx-1"`) {
+		t.Fatalf("output missing id = %q", out)
+	}
+	if !strings.Contains(out, `"merchant":"Store"`) {
+		t.Fatalf("output missing merchant = %q", out)
+	}
+	if !strings.Contains(out, `"category":"Food"`) {
+		t.Fatalf("output missing category = %q", out)
+	}
+}
+
+func testTransactionsCreate(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsCreateCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Common_CreateTransactionMutation" {
+			t.Fatalf("operation = %q, want Common_CreateTransactionMutation", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"createTransaction":{"transaction":{"id":"tx-1","amount":-20,"date":"2026-05-08","merchant":{"name":"Store"}}}}}`), nil
+	})
+
+	_ = transactionsCreateCmd.Flags().Set("amount", "-20")
+	_ = transactionsCreateCmd.Flags().Set("merchant", "Store")
+	_ = transactionsCreateCmd.Flags().Set("date", "2026-05-08")
+	_ = transactionsCreateCmd.Flags().Set("category", "cat-food")
+	_ = transactionsCreateCmd.Flags().Set("account", "acc-1")
+	out := captureStdout(t, func() {
+		transactionsCreateCmd.Run(transactionsCreateCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.create"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, "tx-1") {
+		t.Fatalf("output missing transaction ID = %q", out)
+	}
+}
+
+func testTransactionsUpdate(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsUpdateCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Web_TransactionDrawerUpdateTransaction" {
+			t.Fatalf("operation = %q, want Web_TransactionDrawerUpdateTransaction", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"updateTransaction":{"transaction":{"id":"tx-1","amount":0,"date":"","notes":"updated","hideFromReports":false,"needsReview":false,"category":{"name":"Food"},"merchant":{"name":""}}}}}`), nil
+	})
+
+	_ = transactionsUpdateCmd.Flags().Set("notes", "updated")
+	out := captureStdout(t, func() {
+		transactionsUpdateCmd.Run(transactionsUpdateCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.update"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"notes":"updated"`) {
+		t.Fatalf("output missing notes = %q", out)
+	}
+}
+
+func testTransactionsDelete(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsDeleteCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Common_DeleteTransactionMutation" {
+			t.Fatalf("operation = %q, want Common_DeleteTransactionMutation", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"deleteTransaction":{"deleted":true}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsDeleteCmd.Run(transactionsDeleteCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.delete"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"deleted"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testTransactionsSummary(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsSummaryCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransactionsPage" {
+			t.Fatalf("operation = %q, want GetTransactionsPage", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"aggregates":[{"summary":{"avg":20,"count":1,"max":20,"sum":20,"sumIncome":0,"sumExpense":20}}]}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsSummaryCmd.Run(transactionsSummaryCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.summary"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"sum_expense":20`) {
+		t.Fatalf("output missing sum_expense = %q", out)
+	}
+}
+
+func testTransactionsExportJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsExportCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		return testutil.JSONResponse(`{"data":{"allTransactions":{"results":[{"id":"tx-1","date":"2026-05-08","amount":-20,"merchant":{"name":"Store"},"category":{"name":"Food"},"notes":"lunch","tags":[],"goal":{"id":"","name":""},"account":{"id":"acc-1","displayName":"Checking","order":0,"type":{"group":"depository"}},"ownedByUser":{"displayName":"Test User"}}],"totalCount":1}}}`), nil
+	})
+
+	_ = transactionsExportCmd.Flags().Set("format", "json")
+	out := captureStdout(t, func() {
+		transactionsExportCmd.Run(transactionsExportCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.export"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, "Store") {
+		t.Fatalf("output missing merchant = %q", out)
+	}
+}
+
+func testTransactionsTagsSet(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsTagsSetCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Web_SetTransactionTags" {
+			t.Fatalf("operation = %q, want Web_SetTransactionTags", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"setTransactionTags":{}}}`), nil
+	})
+
+	tagIDs = nil
+	_ = transactionsTagsSetCmd.Flags().Set("tag", "tag-1,tag-2")
+	out := captureStdout(t, func() {
+		transactionsTagsSetCmd.Run(transactionsTagsSetCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.tags.set"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"tags set"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testTransactionsTagsClear(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsTagsClearCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "Web_SetTransactionTags" {
+			t.Fatalf("operation = %q, want Web_SetTransactionTags", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"setTransactionTags":{}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsTagsClearCmd.Run(transactionsTagsClearCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.tags.clear"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"tags cleared"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+}
+
+func testTransactionsTagsAdd(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsTagsAddCmd)
+	saveTestSession(t, sessionPath)
+
+	callCount := 0
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		callCount++
+		if callCount == 1 {
+			if gqlReq.OperationName != "GetTransaction" {
+				t.Fatalf("call %d: operation = %q, want GetTransaction", callCount, gqlReq.OperationName)
+			}
+			return testutil.JSONResponse(`{"data":{"getTransaction":{"id":"tx-1","date":"2026-05-08","amount":-20,"merchant":{"name":"Store"},"category":{"name":"Food"},"notes":"lunch","account":{"id":"acc-1","displayName":"Checking"},"tags":[{"id":"tag-old","name":"existing","color":"#ff0000"}]}}}`), nil
+		}
+		if gqlReq.OperationName != "Web_SetTransactionTags" {
+			t.Fatalf("call %d: operation = %q, want Web_SetTransactionTags", callCount, gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"setTransactionTags":{}}}`), nil
+	})
+
+	tagIDs = nil
+	_ = transactionsTagsAddCmd.Flags().Set("tag", "tag-new")
+	out := captureStdout(t, func() {
+		transactionsTagsAddCmd.Run(transactionsTagsAddCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.tags.add"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"status":"tags added"`) {
+		t.Fatalf("output missing status = %q", out)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func testTransactionsSplits(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsSplitsCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "TransactionSplitQuery" {
+			t.Fatalf("operation = %q, want TransactionSplitQuery", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"getTransaction":{"id":"tx-1","amount":-60,"splitTransactions":[{"id":"split-1","amount":-20,"notes":"part1","merchant":{"name":"Store"},"category":{"name":"Food"}},{"id":"split-2","amount":-40,"notes":"part2","merchant":{"name":"Store"},"category":{"name":"Drinks"}}]}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsSplitsCmd.Run(transactionsSplitsCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.splits"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"category":"Food"`) {
+		t.Fatalf("output missing category = %q", out)
+	}
+}
+
+func testTransactionsBulkCategorize(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsBulkCategorizeCmd)
+	saveTestSession(t, sessionPath)
+
+	callCount := 0
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		callCount++
+		if gqlReq.OperationName != "Web_TransactionDrawerUpdateTransaction" {
+			t.Fatalf("call %d: operation = %q, want Web_TransactionDrawerUpdateTransaction", callCount, gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"updateTransaction":{"transaction":{"id":"tx-1","amount":0,"date":"","notes":"","hideFromReports":false,"needsReview":false,"category":{"name":"Food"},"merchant":{"name":""}}}}}`), nil
+	})
+
+	bulkTxIDs = nil
+	bulkCategoryID = ""
+	_ = transactionsBulkCategorizeCmd.Flags().Set("id", "tx-1,tx-2")
+	_ = transactionsBulkCategorizeCmd.Flags().Set("category-id", "cat-food")
+	out := captureStdout(t, func() {
+		transactionsBulkCategorizeCmd.Run(transactionsBulkCategorizeCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.bulk-categorize"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"successful":2`) {
+		t.Fatalf("output missing successful count = %q", out)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 API calls, got %d", callCount)
+	}
+}
+
+func testTransactionsAttachmentsList(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsAttachmentsListCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransaction" {
+			t.Fatalf("operation = %q, want GetTransaction", gqlReq.OperationName)
+		}
+		return testutil.JSONResponse(`{"data":{"getTransaction":{"attachments":[{"id":"att-1","extension":"pdf","filename":"receipt.pdf","originalAssetUrl":"https://example.com/receipt.pdf","sizeBytes":1024}]}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsAttachmentsListCmd.Run(transactionsAttachmentsListCmd, []string{"tx-1"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.attachments.list"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, "receipt.pdf") {
+		t.Fatalf("output missing filename = %q", out)
+	}
+}
+
+func testTransactionsAttachmentsUpload(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withWriteCommandTestDefaults(t, sessionPath, transactionsAttachmentsUploadCmd)
+	saveTestSession(t, sessionPath)
+
+	out := captureStdout(t, func() {
+		transactionsAttachmentsUploadCmd.Run(transactionsAttachmentsUploadCmd, []string{"tx-1", "/tmp/file.pdf"})
+	})
+
+	if *exitCode == 0 {
+		t.Fatalf("exitCode = 0, want FEATURE_UNAVAILABLE; output=%q", out)
+	}
+	if !strings.Contains(out, `"FEATURE_UNAVAILABLE"`) {
+		t.Fatalf("output = %q, want FEATURE_UNAVAILABLE", out)
+	}
+}
+
+func testTransactionsSearch(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, transactionsSearchCmd)
+	saveTestSession(t, sessionPath)
+
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string         `json:"operationName"`
+			Variables     map[string]any `json:"variables"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		if gqlReq.OperationName != "GetTransactionsList" {
+			t.Fatalf("operation = %q, want GetTransactionsList", gqlReq.OperationName)
+		}
+		filters := gqlReq.Variables["filters"].(map[string]any)
+		if filters["search"] != "Amazon" {
+			t.Fatalf("search = %v, want Amazon", filters["search"])
+		}
+		return testutil.JSONResponse(`{"data":{"allTransactions":{"results":[{"id":"tx-1","date":"2026-05-08","amount":-50,"merchant":{"name":"Amazon"},"category":{"name":"Shopping"},"notes":"order","tags":[],"goal":{"id":"","name":""},"account":{"id":"acc-1","displayName":"Checking","order":0,"type":{"group":"depository"}},"ownedByUser":{"displayName":"Test User"}}],"totalCount":1}}}`), nil
+	})
+
+	out := captureStdout(t, func() {
+		transactionsSearchCmd.Run(transactionsSearchCmd, []string{"Amazon"})
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"transactions.search"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"total":1`) {
+		t.Fatalf("output missing total = %q", out)
+	}
+}

--- a/internal/errors/codes_test.go
+++ b/internal/errors/codes_test.go
@@ -1,0 +1,56 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCodeConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     Code
+		expected string
+	}{
+		{"AuthRequired", AuthRequired, "AUTH_REQUIRED"},
+		{"AuthSessionExpired", AuthSessionExpired, "AUTH_SESSION_EXPIRED"},
+		{"AuthMFARequired", AuthMFARequired, "AUTH_MFA_REQUIRED"},
+		{"AuthMFAInvalid", AuthMFAInvalid, "AUTH_MFA_INVALID"},
+		{"NetworkUnreachable", NetworkUnreachable, "NETWORK_UNREACHABLE"},
+		{"NetworkTimeout", NetworkTimeout, "NETWORK_TIMEOUT"},
+		{"APIError", APIError, "API_ERROR"},
+		{"APISchemaChanged", APISchemaChanged, "API_SCHEMA_CHANGED"},
+		{"FEATURE_UNAVAILABLE", FEATURE_UNAVAILABLE, "FEATURE_UNAVAILABLE"},
+		{"ValidationFailed", ValidationFailed, "VALIDATION_FAILED"},
+		{"ReadOnlyViolation", ReadOnlyViolation, "READ_ONLY_VIOLATION"},
+		{"ConfirmationRequired", ConfirmationRequired, "CONFIRMATION_REQUIRED"},
+		{"ResourceNotFound", ResourceNotFound, "RESOURCE_NOT_FOUND"},
+		{"InternalError", InternalError, "INTERNAL_ERROR"},
+		{"InvalidArguments", InvalidArguments, "INVALID_ARGUMENTS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.code))
+		})
+	}
+}
+
+func TestCategoryConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		cat      Category
+		expected string
+	}{
+		{"CatAuth", CatAuth, "auth"},
+		{"CatNetwork", CatNetwork, "network"},
+		{"CatAPI", CatAPI, "api"},
+		{"CatValidation", CatValidation, "validation"},
+		{"CatSafety", CatSafety, "safety"},
+		{"CatInternal", CatInternal, "internal"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.cat))
+		})
+	}
+}

--- a/internal/output/envelope_test.go
+++ b/internal/output/envelope_test.go
@@ -1,0 +1,116 @@
+package output
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thedavidweng/monarchmoney-cli/internal/errors"
+)
+
+func TestNewEnvelope(t *testing.T) {
+	t.Run("sets ok to true and populates all fields", func(t *testing.T) {
+		data := map[string]string{"key": "value"}
+		dur := 150 * time.Millisecond
+
+		env := NewEnvelope("get-accounts", "default", "1.0", "req-123", data, dur)
+
+		require.NotNil(t, env)
+		assert.True(t, env.OK)
+		assert.Equal(t, data, env.Data)
+		assert.Equal(t, "get-accounts", env.Meta.Command)
+		assert.Equal(t, "default", env.Meta.Profile)
+		assert.Equal(t, "1.0", env.Meta.SchemaVersion)
+		assert.Equal(t, "req-123", env.Meta.RequestID)
+		assert.Equal(t, int64(150), env.Meta.DurationMS)
+	})
+
+	t.Run("with nil data", func(t *testing.T) {
+		env := NewEnvelope("cmd", "p", "1", "r", nil, 0)
+
+		require.NotNil(t, env)
+		assert.True(t, env.OK)
+		assert.Nil(t, env.Data)
+	})
+
+	t.Run("with empty strings", func(t *testing.T) {
+		env := NewEnvelope("", "", "", "", "something", 0)
+
+		require.NotNil(t, env)
+		assert.True(t, env.OK)
+		assert.Equal(t, "", env.Meta.Command)
+		assert.Equal(t, "", env.Meta.Profile)
+		assert.Equal(t, "", env.Meta.SchemaVersion)
+		assert.Equal(t, "", env.Meta.RequestID)
+	})
+
+	t.Run("with zero duration", func(t *testing.T) {
+		env := NewEnvelope("cmd", "p", "1", "r", "d", 0)
+
+		assert.Equal(t, int64(0), env.Meta.DurationMS)
+	})
+
+	t.Run("converts duration to milliseconds correctly", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			dur      time.Duration
+			expected int64
+		}{
+			{"1ms", 1 * time.Millisecond, 1},
+			{"1s", 1 * time.Second, 1000},
+			{"250ms", 250 * time.Millisecond, 250},
+			{"1m", 1 * time.Minute, 60000},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				env := NewEnvelope("cmd", "p", "1", "r", nil, tt.dur)
+				assert.Equal(t, tt.expected, env.Meta.DurationMS)
+			})
+		}
+	})
+}
+
+func TestNewErrorEnvelope(t *testing.T) {
+	t.Run("sets ok to false and populates all fields", func(t *testing.T) {
+		err := errors.New(errors.AuthRequired, "login needed", errors.CatAuth, false, nil)
+		dur := 50 * time.Millisecond
+
+		env := NewErrorEnvelope("sync", "work", "1.0", err, dur)
+
+		require.NotNil(t, env)
+		assert.False(t, env.OK)
+		assert.Equal(t, err, env.Error)
+		assert.Equal(t, "sync", env.Meta.Command)
+		assert.Equal(t, "work", env.Meta.Profile)
+		assert.Equal(t, "1.0", env.Meta.SchemaVersion)
+		assert.Equal(t, int64(50), env.Meta.DurationMS)
+	})
+
+	t.Run("with nil error", func(t *testing.T) {
+		env := NewErrorEnvelope("cmd", "p", "1", nil, 0)
+
+		require.NotNil(t, env)
+		assert.False(t, env.OK)
+		assert.Nil(t, env.Error)
+	})
+
+	t.Run("with empty strings and zero duration", func(t *testing.T) {
+		err := errors.New(errors.InternalError, "", errors.CatInternal, true, nil)
+		env := NewErrorEnvelope("", "", "", err, 0)
+
+		require.NotNil(t, env)
+		assert.False(t, env.OK)
+		assert.Equal(t, "", env.Meta.Command)
+		assert.Equal(t, "", env.Meta.Profile)
+		assert.Equal(t, "", env.Meta.SchemaVersion)
+		assert.Equal(t, int64(0), env.Meta.DurationMS)
+	})
+
+	t.Run("converts duration to milliseconds correctly", func(t *testing.T) {
+		err := errors.New(errors.NetworkTimeout, "timeout", errors.CatNetwork, true, nil)
+		env := NewErrorEnvelope("cmd", "p", "1", err, 3*time.Second+250*time.Millisecond)
+
+		assert.Equal(t, int64(3250), env.Meta.DurationMS)
+	})
+}


### PR DESCRIPTION
## Summary
- Add 22 new test files covering all previously untested CLI commands and small packages
- Total test count: ~150 → **441 tests**
- Statement coverage: → **88.5%**
- Update `codecov.yml` to exclude untestable files (cmd/, version/, testutil/, queries/, Windows platform files)

## What's tested

**CLI commands** (18 new test files):
- `accounts` — 18 subtests covering list, show, holdings, balance-at, history, refresh, update, delete, create-manual, upload-history, types, refresh-status, recent-balances, snapshots, aggregate-snapshots, networth
- `transactions` — 17 subtests covering list, show, create, update, delete, summary, export, splits, search, tags (set/add/clear), bulk-categorize, attachments (list/upload)
- `budgets` — 9 subtests covering list, export, reset, flexible set, flex-rollover set + validation errors
- `cashflow` — 11 subtests covering summary, categories, merchants, spending, list, trends + date/group-by validation
- `categories` — 6 subtests covering list, groups, delete, delete-many + file validation
- `tags`, `goals`, `recurring`, `rules`, `subscription`, `institutions` — 2-3 subtests each
- `credit`, `investments` — portfolio, performance + API errors
- `deps`, `doctor`, `audit`, `completion`, `banner`, `metadata` — command registration, validation, error handling

**Small packages** (2 new test files):
- `internal/output/envelope_test.go` — NewEnvelope, NewErrorEnvelope field mapping
- `internal/errors/codes_test.go` — all 15 Code + 6 Category constants

## Test patterns

All CLI tests follow the established patterns from `auth_test.go` and `cache_test.go`:
- Package-level var injection via `withReadCommandTestDefaults` / `withWriteCommandTestDefaults`
- HTTP mocking via `testutil.RoundTripFunc` on `http.DefaultTransport`
- Stdout capture via `captureStdout`
- JSON envelope assertions

## Codecov config changes

Added `ignore` for files that can't be meaningfully tested:
- `cmd/**` — trivial main(), covered by E2E
- `internal/version/**` — build-time ldflags injection
- `internal/testutil/**` — test helpers
- `queries/**` — go:embed directive
- Windows platform files

## Test plan
- [x] All 441 tests pass (`go test ./... -count=1`)
- [x] No regressions in existing tests
- [ ] Verify Codecov reports improved coverage after merge