### PR TITLE
fix: harden release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: rp
         with:
           skip-github-release: true
@@ -33,7 +33,10 @@ jobs:
           set -e
           VERSION="${TAG#v}"
           ESCAPED_VERSION=$(printf '%s' "${VERSION}" | sed 's/\./\\./g')
-          NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          NOTES=''
+          if [ -f CHANGELOG.md ]; then
+            NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
+          fi
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "${NOTES:-Release $TAG}" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,17 +18,27 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        id: rp
-        with:
-          skip-github-release: true
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - name: Check if release is needed
+        id: check
+        run: |
+          set -e
+          MANIFEST_VERSION=$(jq -r '."."' .release-please-manifest.json)
+          LATEST_TAG=$(git tag --sort=-v:refname | head -1)
+          LATEST_VERSION="${LATEST_TAG#v}"
+          if [ "$MANIFEST_VERSION" = "$LATEST_VERSION" ]; then
+            echo "No release needed (manifest=$MANIFEST_VERSION, tag=$LATEST_VERSION)"
+            echo "release_created=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Release needed: $LATEST_VERSION -> $MANIFEST_VERSION"
+            echo "release_created=true" >> "$GITHUB_OUTPUT"
+            echo "tag_name=v${MANIFEST_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
-        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        if: ${{ steps.check.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          TAG: ${{ steps.rp.outputs.tag_name }}
+          TAG: ${{ steps.check.outputs.tag_name }}
         run: |
           set -e
           VERSION="${TAG#v}"
@@ -37,15 +47,15 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
-          gh release create "$TAG" --draft \
+          git tag "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" \
             --title "$TAG" \
             --notes "${NOTES:-Release $TAG}" \
             --verify-tag
 
-      - name: Publish release
-        if: ${{ steps.rp.outputs.release_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          TAG: ${{ steps.rp.outputs.tag_name }}
-        run: |
-          gh release edit "$TAG" --draft=false
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: rp
+        with:
+          skip-github-release: true
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           set -e
           MANIFEST_VERSION=$(jq -r '."."' .release-please-manifest.json)
-          LATEST_TAG=$(git tag --sort=-v:refname | head -1)
+          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
           LATEST_VERSION="${LATEST_TAG#v}"
           if [ "$MANIFEST_VERSION" = "$LATEST_VERSION" ]; then
             echo "No release needed (manifest=$MANIFEST_VERSION, tag=$LATEST_VERSION)"
@@ -34,7 +34,7 @@ jobs:
             echo "tag_name=v${MANIFEST_VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create GitHub Release
+      - name: Create draft release
         if: ${{ steps.check.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -47,11 +47,27 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
+          gh release create "$TAG" --draft \
+            --title "$TAG" \
+            --notes "${NOTES:-Release $TAG}"
+
+      - name: Push tag
+        if: ${{ steps.check.outputs.release_created == 'true' }}
+        env:
+          TAG: ${{ steps.check.outputs.tag_name }}
+        run: |
+          set -e
           git tag "$TAG"
           git push origin "$TAG"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "${NOTES:-Release $TAG}" \
+
+      - name: Publish release
+        if: ${{ steps.check.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          TAG: ${{ steps.check.outputs.tag_name }}
+        run: |
+          set -e
+          gh release edit "$TAG" --draft=false
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: rp

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,10 @@ EOF
           FULL_NOTES="${NOTES:-Release $TAG}
 
 ${INSTALL}"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "${FULL_NOTES}"
+          if gh release view "$TAG" &>/dev/null; then
+            gh release edit "$TAG" --notes "${FULL_NOTES}"
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "${FULL_NOTES}"
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,6 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "${NOTES:-Release $TAG}" \
-            --verify-tag
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: rp

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,15 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
-          gh release create "$TAG" \
+          gh release create "$TAG" --draft \
             --title "$TAG" \
             --notes "${NOTES:-Release $TAG}" \
             --verify-tag
+
+      - name: Publish release
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          TAG: ${{ steps.rp.outputs.tag_name }}
+        run: |
+          gh release edit "$TAG" --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
             echo "tag_name=v${MANIFEST_VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create draft release
+      - name: Create GitHub Release
         if: ${{ steps.check.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -47,27 +47,11 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
-          gh release create "$TAG" --draft \
-            --title "$TAG" \
-            --notes "${NOTES:-Release $TAG}"
-
-      - name: Push tag
-        if: ${{ steps.check.outputs.release_created == 'true' }}
-        env:
-          TAG: ${{ steps.check.outputs.tag_name }}
-        run: |
-          set -e
           git tag "$TAG"
           git push origin "$TAG"
-
-      - name: Publish release
-        if: ${{ steps.check.outputs.release_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          TAG: ${{ steps.check.outputs.tag_name }}
-        run: |
-          set -e
-          gh release edit "$TAG" --draft=false
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "${NOTES:-Release $TAG}"
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: rp

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,13 +40,13 @@ jobs:
           INSTALL=$(cat <<'EOF'
 # Installation
 
-\`\`\`bash
+```bash
 # Homebrew (macOS)
 brew install --cask thedavidweng/tap/monarchmoney-cli
 
 # Go (cross-platform)
 go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@VERSION_PLACEHOLDER
-\`\`\`
+```
 EOF
           )
           INSTALL="${INSTALL/VERSION_PLACEHOLDER/$TAG}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,9 +49,21 @@ jobs:
           fi
           git tag "$TAG"
           git push origin "$TAG"
+          INSTALL='# Installation
+
+          ```bash
+          # Homebrew (macOS)
+          brew install --cask thedavidweng/tap/monarchmoney-cli
+
+          # Go (cross-platform)
+          go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@TAG
+          ```'
+          FULL_NOTES="${NOTES:-Release $TAG}
+
+          ${INSTALL}"
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes "${NOTES:-Release $TAG}"
+            --notes "${FULL_NOTES}"
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: rp

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,7 +56,7 @@ jobs:
           brew install --cask thedavidweng/tap/monarchmoney-cli
 
           # Go (cross-platform)
-          go install github.com/thedavidweng/monarchmoney-cli/./cmd/monarch@${TAG}
+          go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@${TAG}
           ```"
           FULL_NOTES="${NOTES:-Release $TAG}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,15 +49,15 @@ jobs:
           fi
           git tag "$TAG"
           git push origin "$TAG"
-          INSTALL='# Installation
+                    INSTALL="# Installation
 
           ```bash
           # Homebrew (macOS)
           brew install --cask thedavidweng/tap/monarchmoney-cli
 
           # Go (cross-platform)
-          go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@TAG
-          ```'
+          go install github.com/thedavidweng/monarchmoney-cli/./cmd/monarch@${TAG}
+          ```"
           FULL_NOTES="${NOTES:-Release $TAG}
 
           ${INSTALL}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,15 +37,19 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
-          INSTALL="# Installation
+                    INSTALL=$(cat <<'EOF'
+          # Installation
 
-          \`\`\`bash
+          ```bash
           # Homebrew (macOS)
           brew install --cask thedavidweng/tap/monarchmoney-cli
 
           # Go (cross-platform)
-          go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@${TAG}
-          \`\`\`"
+          go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@VERSION_PLACEHOLDER
+          ```
+          EOF
+          )
+          INSTALL="${INSTALL/VERSION_PLACEHOLDER/$TAG}"
           FULL_NOTES="${NOTES:-Release $TAG}
 
           ${INSTALL}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,22 +37,22 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
-                    INSTALL=$(cat <<'EOF'
-          # Installation
+          INSTALL=$(cat <<'EOF'
+# Installation
 
-          ```bash
-          # Homebrew (macOS)
-          brew install --cask thedavidweng/tap/monarchmoney-cli
+\`\`\`bash
+# Homebrew (macOS)
+brew install --cask thedavidweng/tap/monarchmoney-cli
 
-          # Go (cross-platform)
-          go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@VERSION_PLACEHOLDER
-          ```
-          EOF
+# Go (cross-platform)
+go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@VERSION_PLACEHOLDER
+\`\`\`
+EOF
           )
           INSTALL="${INSTALL/VERSION_PLACEHOLDER/$TAG}"
           FULL_NOTES="${NOTES:-Release $TAG}
 
-          ${INSTALL}"
+${INSTALL}"
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "${FULL_NOTES}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,27 +18,17 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
-      - name: Check if release is needed
-        id: check
-        run: |
-          set -e
-          MANIFEST_VERSION=$(jq -r '."."' .release-please-manifest.json)
-          LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -1)
-          LATEST_VERSION="${LATEST_TAG#v}"
-          if [ "$MANIFEST_VERSION" = "$LATEST_VERSION" ]; then
-            echo "No release needed (manifest=$MANIFEST_VERSION, tag=$LATEST_VERSION)"
-            echo "release_created=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Release needed: $LATEST_VERSION -> $MANIFEST_VERSION"
-            echo "release_created=true" >> "$GITHUB_OUTPUT"
-            echo "tag_name=v${MANIFEST_VERSION}" >> "$GITHUB_OUTPUT"
-          fi
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: rp
+        with:
+          skip-github-release: true
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Create GitHub Release
-        if: ${{ steps.check.outputs.release_created == 'true' }}
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          TAG: ${{ steps.check.outputs.tag_name }}
+          TAG: ${{ steps.rp.outputs.tag_name }}
         run: |
           set -e
           VERSION="${TAG#v}"
@@ -47,26 +37,18 @@ jobs:
           if [ -f CHANGELOG.md ]; then
             NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md || true)
           fi
-          git tag "$TAG"
-          git push origin "$TAG"
-                    INSTALL="# Installation
+          INSTALL="# Installation
 
-          ```bash
+          \`\`\`bash
           # Homebrew (macOS)
           brew install --cask thedavidweng/tap/monarchmoney-cli
 
           # Go (cross-platform)
           go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@${TAG}
-          ```"
+          \`\`\`"
           FULL_NOTES="${NOTES:-Release $TAG}
 
           ${INSTALL}"
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "${FULL_NOTES}"
-
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
-        id: rp
-        with:
-          skip-github-release: true
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,52 +12,29 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.check.outputs.release_created }}
-      tag_name: ${{ steps.check.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Check if release is needed
-        id: check
-        run: |
-          MANIFEST_VERSION=$(jq -r '."."' .release-please-manifest.json)
-          LATEST_TAG=$(git tag --sort=-v:refname | head -1)
-          LATEST_VERSION="${LATEST_TAG#v}"
-
-          if [ "$MANIFEST_VERSION" = "$LATEST_VERSION" ]; then
-            echo "No release needed (manifest=$MANIFEST_VERSION, tag=$LATEST_VERSION)"
-            echo "release_created=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Release needed: $LATEST_VERSION -> $MANIFEST_VERSION"
-            echo "release_created=true" >> "$GITHUB_OUTPUT"
-            echo "tag_name=v${MANIFEST_VERSION}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create tag and GitHub Release
-        if: ${{ steps.check.outputs.release_created == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          TAG: ${{ steps.check.outputs.tag_name }}
-        run: |
-          VERSION="${TAG#v}"
-
-          # Create tag at current HEAD
-          git tag "$TAG"
-          git push origin "$TAG"
-
-          # Extract release notes from CHANGELOG.md
-          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
-
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "${NOTES:-Release $TAG}" \
-            --verify-tag
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - uses: googleapis/release-please-action@v4
         id: rp
         with:
           skip-github-release: true
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Create GitHub Release
+        if: ${{ steps.rp.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          TAG: ${{ steps.rp.outputs.tag_name }}
+        run: |
+          set -e
+          VERSION="${TAG#v}"
+          ESCAPED_VERSION=$(printf '%s' "${VERSION}" | sed 's/\./\\./g')
+          NOTES=$(awk "/^## \[${ESCAPED_VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "${NOTES:-Release $TAG}" \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,35 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
 
 jobs:
+  wait:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          echo "Waiting for release $TAG to exist..."
+          for i in $(seq 1 30); do
+            if gh release view "$TAG" &>/dev/null; then
+              echo "Release $TAG found after ~${i}0 seconds"
+              exit 0
+            fi
+            echo "Attempt $i/30: release not found yet, waiting 10s..."
+            sleep 10
+          done
+          echo "::warning::Release $TAG not found after 5 minutes, proceeding anyway"
+
   release:
+    needs: wait
     uses: thedavidweng/cli-workflow-template/.github/workflows/go-release.yml@main
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,35 +5,11 @@ on:
     tags:
       - 'v*'
 
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
-
 permissions:
   contents: write
   id-token: write
 
 jobs:
-  wait:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          echo "Waiting for release $TAG to exist..."
-          for i in $(seq 1 30); do
-            if gh release view "$TAG" &>/dev/null; then
-              echo "Release $TAG found after ~${i}0 seconds"
-              exit 0
-            fi
-            echo "Attempt $i/30: release not found yet, waiting 10s..."
-            sleep 10
-          done
-          echo "::warning::Release $TAG not found after 5 minutes, proceeding anyway"
-
   release:
-    needs: wait
     uses: thedavidweng/cli-workflow-template/.github/workflows/go-release.yml@main
     secrets: inherit

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,36 +78,6 @@ release:
   mode: keep-existing
   draft: false
   prerelease: auto
-  header: |
-    ## What's Changed
-
-    Full release notes are auto-generated below. See the [README](https://github.com/thedavidweng/monarchmoney-cli#readme) for usage.
-  footer: |
-    ---
-    **Installation:**
-    ```bash
-    # Homebrew (macOS)
-    brew install --cask thedavidweng/tap/monarchmoney-cli
-
-    # Linux (deb/rpm/apk — see assets below)
-    # curl -LO https://github.com/thedavidweng/monarchmoney-cli/releases/download/{{ .Tag }}/monarch_linux_amd64.deb
-    # sudo dpkg -i monarch_linux_amd64.deb
-
-    # Windows (zip — see assets below)
-    # Extract monarch_windows_x86_64.zip and add to PATH
-
-    # Go (cross-platform)
-    go install github.com/thedavidweng/monarchmoney-cli/cmd/monarch@{{ .Tag }}
-    ```
-
-    **Verify checksum:**
-    ```bash
-    cosign verify-blob \
-      --bundle checksums.txt.sig \
-      --certificate-identity-regexp='https://github.com/thedavidweng/monarchmoney-cli' \
-      --certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-      checksums.txt
-    ```
 
 nfpms:
   - package_name: monarch

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,7 +75,7 @@ release:
   github:
     owner: thedavidweng
     name: monarchmoney-cli
-  mode: append
+  mode: keep-existing
   draft: false
   prerelease: auto
   header: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -75,7 +75,7 @@ release:
   github:
     owner: thedavidweng
     name: monarchmoney-cli
-  mode: keep-existing
+  mode: append
   draft: false
   prerelease: auto
 


### PR DESCRIPTION
## Summary

This PR fixes several issues in the release-please workflow that could cause failed or silent releases.

### Fixes

1. **Checkout uses PAT so tag pushes trigger GoReleaser workflow** — The default  creates tag pushes that do *not* trigger other workflows. Using  (a PAT) ensures the GoReleaser workflow fires on tag push.

2. **Removed manual version detection** — The previous workflow manually compared the manifest version to the latest tag to decide if a release was needed. This was fragile and redundant since release-please-action already handles this via its  output.

3. **Escaped version dots in awk regex** — In the old workflow, version dots (e.g. `1.2.3`) were used literally in the awk regex, matching any character instead of a literal dot. Now dots are escaped with `sed 's/\./\\./g'`.

4. **Added `set -e` for fail-fast on errors** — Without it, a failed `awk` or `gh release create` command could silently succeed, masking real problems.

5. **Removed dead job outputs** — The old workflow declared `release_created` and `tag_name` as job outputs but never consumed them downstream. Removed to avoid confusion.

6. **Eliminated potential tag conflict with release-please-action** — The old workflow manually created and pushed tags *before* running release-please-action, which could conflict with the tags release-please creates. Now the action runs first and handles tag creation.