### PR TITLE
fix: add force_push and fetch-depth: 0

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
 
       - name: Mirror to Codeberg
         uses: cssnr/mirror-repository-action@2af5bf347684245f52b5f56502956a57f9b8813e # v1
@@ -25,3 +27,4 @@ jobs:
           host: https://codeberg.org
           username: thedavidweng
           password: ${{ secrets.CODEBERG_TOKEN }}
+          force_push: true


### PR DESCRIPTION
Fix mirror workflow: force push to overwrite Codeberg, full clone.