### PR TITLE
feat: HTTP hardening, mutation no-retry, overview command, VCS build info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: thedavidweng/cli-workflow-template/.github/workflows/go-ci.yml@main

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -11,6 +11,7 @@
 | **Rules** | List, create, update, delete auto-categorization rules | `monarch rules` |
 | **Budgets** | List, show, set, reset, flexible, rollover | `monarch budgets` |
 | **Cashflow** | Summary, category/merchant breakdown, grouped trends, spending totals | `monarch cashflow` |
+| **Overview** | Net worth, cashflow, and recent transactions in one call | `monarch overview` |
 | **Analysis** | Deterministic anomaly, subscription, merchant, and budget burn-rate analysis | `monarch analyze` |
 | **Categories** | List, groups, create, delete | `monarch categories` |
 | **Goals** | List goals | `monarch goals` |
@@ -58,6 +59,7 @@
 - `monarch cashflow categories`: View spending by category.
 - `monarch cashflow merchants`: View spending by merchant.
 - `monarch cashflow trends`: View aggregate trends by category or category group and period.
+- `monarch overview`: Get a compact financial overview (net worth, cashflow, recent transactions) for the current month or a custom range via `--from`/`--to`.
 - `monarch goals list`: List goals.
 - `monarch investments portfolio`: View portfolio performance and holdings.
 - `monarch investments performance`: View historical security performance.

--- a/JSON_SCHEMA.md
+++ b/JSON_SCHEMA.md
@@ -49,6 +49,7 @@
 - `error.message`: A human-readable description of the error.
 - `error.category`: High-level error grouping (`auth`, `network`, `api`, `validation`, `safety`, `internal`).
 - `error.retryable`: Boolean indicating if the operation can be safely retried.
+- `error.retry_after_ms`: Present on `RATE_LIMITED` and retryable 5xx errors when the server supplies a `Retry-After` header. Milliseconds to wait before retrying.
 
 ## Exit Codes
 
@@ -67,6 +68,7 @@ The process exit code is derived from `error.code` (see `internal/errors`). A su
 | 4 | `READ_ONLY_VIOLATION` | safety |
 | 5 | `NETWORK_UNREACHABLE` | network |
 | 5 | `NETWORK_TIMEOUT` | network |
+| 5 | `RATE_LIMITED` | api |
 | 6 | `API_ERROR` | api |
 | 6 | `API_SCHEMA_CHANGED` | api |
 | 6 | `FEATURE_UNAVAILABLE` | api |

--- a/docs/adr/0007-http-hardening-mutation-safety-overview.md
+++ b/docs/adr/0007-http-hardening-mutation-safety-overview.md
@@ -1,0 +1,48 @@
+# 0007 - HTTP hardening, mutation no-retry, overview command
+
+## Status
+
+Accepted.
+
+## Context
+
+The GraphQL client (`internal/graphql/client.go`) and the REST login path (`internal/auth/login.go`) used Go's default `http.Client`, which silently follows 3xx redirects. A misconfigured endpoint, a hostile intermediary, or a future Monarch API change that redirects the GraphQL endpoint to an attacker-controlled host would let the bearer token leak to that host with no error surfaced to the user. The fork (`matteing/monarch-cli`) rejects redirects explicitly via `httpx.RejectRedirects`; this CLI did not.
+
+The same client retried every call up to three times, including mutations. A transport failure mid-request is ambiguous: Monarch may have already applied the write. Retrying a `DeleteTransaction` or `SetBudget` after a network blip can duplicate the effect or silently succeed twice, leaving the user's books in a state the CLI cannot see. The fork separates read-retry from mutation-no-retry; this CLI did not.
+
+The client also had no rate-limit handling. Monarch returns HTTP 429 with a `Retry-After` header under load; the CLI treated it as a generic non-200 and retried on a fixed backoff, ignoring the server's guidance.
+
+Finally, the CLI had no single command that showed a user "where do I stand right now". The fork's `monarch overview` aggregates net worth, cashflow, and recent transactions in one call; this CLI required three separate invocations.
+
+## Decision
+
+Four changes, each narrowly scoped:
+
+1. **Reject redirects.** `NewClient` sets `CheckRedirect` to a function returning `http.ErrUseLastResponse`, so any 3xx becomes a non-200 and surfaces as an `API_ERROR`. The login HTTP client does the same. A legitimate Monarch API call never redirects; a redirect is always a signal to stop.
+
+2. **Mutation no-retry.** Add `Client.DoMutation`, which executes exactly one attempt. The `graphQLClient` interface in `internal/monarch/service.go` gains `DoMutation`, and every service method that issues a GraphQL mutation (`CreateManualAccount`, `UpdateAccount`, `DeleteAccount`, `RefreshAccounts`, `SetBudget`, `ResetBudget`, `UpdateFlexibleBudget`, `UpdateFlexRolloverSettings`, `CreateCategory`, `DeleteCategory`, `DeleteCategories`, `UpdateRecurringTransaction`, `CreateTransactionRule`, `UpdateTransactionRule`, `DeleteTransactionRule`, `CreateTag`, `UpdateTransaction`, `DeleteTransaction`, `UpdateTransactionSplits`, `CreateTransaction`, `SetTransactionTags`) calls `DoMutation` instead of `Do`. Reads keep the existing retry loop.
+
+3. **Rate-limit and Retry-After.** HTTP 429 produces a new `RATE_LIMITED` error code with the parsed `Retry-After` value (seconds or HTTP-date) stored in a new `Error.RetryAfterMS` field. 5xx responses also parse `Retry-After` and stay retryable. The retry loop honours `RetryAfterMS` when present, capped at 10 seconds to avoid pathological waits. A new `errors.NewWithRetryAfter` constructor populates the field. `RATE_LIMITED` shares exit code 5 with the network errors, since both mean "try again later".
+
+4. **`monarch overview` command.** A new `Service.GetFinancialOverview` fetches accounts, cashflow summary, and the 10 most recent transactions concurrently via `golang.org/x/sync/errgroup`, then computes net worth from visible, net-worth-included accounts. The `overview` CLI command renders the aggregate for humans or emits the JSON envelope. `--from`/`--to` default to the current month.
+
+A new dependency, `golang.org/x/sync/errgroup`, is introduced for the concurrent fetch. It is the standard library's recommended primitive for "N goroutines, fail on first error" and carries no transitive dependencies beyond `golang.org/x/sync`.
+
+## Consequences
+
+### Positive
+
+- A redirect can no longer exfiltrate the bearer token; it is a hard error.
+- Mutations are safe to retry manually but never retried automatically, so a transport failure after a successful write surfaces as an error the user investigates, rather than a silent duplicate.
+- Rate-limit responses carry the server's wait hint into the structured error envelope, so scripts and agents can back off correctly.
+- Users get a single command for a financial snapshot; agents get one JSON envelope instead of three calls.
+
+### Negative
+
+- A mutation that fails after the server applied it now requires the user to reconcile manually. This is the correct failure mode (ambiguous outcome → human judgement) but is less convenient than a silent retry that happens to work.
+- `golang.org/x/sync` is a new external dependency, the first outside the standard library for the monarch service layer. It is minimal and stable.
+
+### Mitigations
+
+- The mutation-no-retry error message names the operation and resource so the user knows exactly what to check.
+- `errgroup` is the only `golang.org/x` dependency; if it ever needs to be removed, the three goroutines can be replaced with a hand-rolled `sync.WaitGroup` plus a channel for the first error, at the cost of ~15 lines.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=

--- a/internal/auth/login.go
+++ b/internal/auth/login.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -15,8 +16,12 @@ import (
 )
 
 var loginEndpoint = "https://api.monarch.com/auth/login/"
+var maxLoginResponseSize = int64(1 << 20)
 var newLoginHTTPClient = func() *http.Client {
-	return &http.Client{Timeout: 10 * time.Second}
+	return &http.Client{
+		Timeout:       10 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
 }
 
 type loginRequest struct {
@@ -78,14 +83,14 @@ func Authenticate(email, password, mfaCode, mfaSecret string) (*Session, error) 
 			Detail    string `json:"detail"`
 			ErrorCode string `json:"error_code"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&apiErr); err == nil && apiErr.Detail != "" {
+		if err := json.NewDecoder(io.LimitReader(resp.Body, maxLoginResponseSize)).Decode(&apiErr); err == nil && apiErr.Detail != "" {
 			return nil, errors.New(errors.APIError, apiErr.Detail, errors.CatAPI, false, nil)
 		}
 		return nil, errors.New(errors.APIError, fmt.Sprintf("API returned status %d", resp.StatusCode), errors.CatAPI, false, nil)
 	}
 
 	var loginResp loginResponse
-	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxLoginResponseSize)).Decode(&loginResp); err != nil {
 		return nil, errors.New(errors.APISchemaChanged, "failed to parse login response", errors.CatAPI, false, err)
 	}
 

--- a/internal/cli/overview.go
+++ b/internal/cli/overview.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/monarch"
+)
+
+var (
+	overviewFrom string
+	overviewTo   string
+)
+
+var overviewCmd = &cobra.Command{
+	Use:     "overview",
+	Short:   "Get a compact financial overview",
+	GroupID: "core",
+	Example: "  monarch overview\n  monarch overview --from 2026-01-01 --to 2026-01-31 --json",
+	Run: func(cmd *cobra.Command, args []string) {
+		run(cmd.Context(), "overview", "failed to get financial overview",
+			func(ctx context.Context, svc *monarch.Service) (*monarch.FinancialOverview, error) {
+				return svc.GetFinancialOverview(ctx, overviewFrom, overviewTo)
+			},
+			func(ov *monarch.FinancialOverview) {
+				fmt.Printf("Financial Overview (as of %s)\n\n", ov.AsOf)
+				fmt.Printf("Net Worth:       %.2f\n", ov.NetWorth)
+				fmt.Printf("Accounts:        %d\n", ov.AccountCount)
+				if ov.Cashflow != nil {
+					fmt.Printf("Income:          %.2f\n", ov.Cashflow.Income)
+					fmt.Printf("Expense:         %.2f\n", ov.Cashflow.Expense)
+					fmt.Printf("Savings:         %.2f\n", ov.Cashflow.Savings)
+					fmt.Printf("Savings Rate:    %.2f%%\n", ov.Cashflow.SavingsRate*100)
+				}
+				fmt.Printf("Transactions:    %d total (showing %d)\n\n", ov.TransactionTotal, len(ov.Transactions))
+				if len(ov.Transactions) > 0 {
+					fmt.Printf("%-12s %-20s %-15s %10s\n", "DATE", "MERCHANT", "CATEGORY", "AMOUNT")
+					for _, tx := range ov.Transactions {
+						merchant := tx.Merchant
+						category := tx.Category
+						fmt.Printf("%-12s %-20s %-15s %10.2f\n", tx.Date, merchant, category, tx.Amount)
+					}
+				}
+			})
+	},
+}
+
+func init() {
+	overviewCmd.Flags().StringVar(&overviewFrom, "from", "", "start date (YYYY-MM-DD, defaults to current month)")
+	overviewCmd.Flags().StringVar(&overviewTo, "to", "", "end date (YYYY-MM-DD, defaults to current month)")
+	RootCmd.AddCommand(overviewCmd)
+}

--- a/internal/cli/overview_test.go
+++ b/internal/cli/overview_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/thedavidweng/monarchmoney-cli/internal/testutil"
+)
+
+func TestOverviewJSON(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, overviewCmd)
+	saveTestSession(t, sessionPath)
+
+	var mu sync.Mutex
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&gqlReq); err != nil {
+			t.Fatalf("Decode request error = %v", err)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		switch gqlReq.OperationName {
+		case "GetAccounts":
+			return testutil.JSONResponse(`{"data":{"accounts":[{"id":"a1","displayName":"Checking","type":{"name":"bank","display":"Bank"},"subtype":{"name":"checking","display":"Checking"},"displayBalance":1000,"currentBalance":1000,"updatedAt":"2026-05-01","isHidden":false,"isAsset":true,"mask":"1234","isManual":false,"includeInNetWorth":true,"includeBalanceInNetWorth":false}]}}`), nil
+		case "GetCashflowSummary":
+			return testutil.JSONResponse(`{"data":{"aggregates":[{"summary":{"sumIncome":5000,"sumExpense":3000,"savings":2000,"savingsRate":0.4}}]}}`), nil
+		case "GetTransactionsList":
+			return testutil.JSONResponse(`{"data":{"allTransactions":{"results":[{"id":"t1","date":"2026-07-01","amount":-50,"pending":false,"category":{"id":"c1","name":"Food","group":{"id":"g1","name":"Expenses","type":"expense"}},"merchant":{"name":"Grocery Store","id":"m1"},"account":{"id":"a1","displayName":"Checking","order":0,"type":{"group":"bank"}}}],"totalCount":42}}}`), nil
+		default:
+			t.Fatalf("unexpected operation %q", gqlReq.OperationName)
+			return nil, nil
+		}
+	})
+
+	out := captureStdout(t, func() {
+		overviewCmd.Run(overviewCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, `"command":"overview"`) {
+		t.Fatalf("output missing command = %q", out)
+	}
+	if !strings.Contains(out, `"net_worth":1000`) {
+		t.Fatalf("output missing net_worth = %q", out)
+	}
+	if !strings.Contains(out, `"account_count":1`) {
+		t.Fatalf("output missing account_count = %q", out)
+	}
+	if !strings.Contains(out, `"transaction_total":42`) {
+		t.Fatalf("output missing transaction_total = %q", out)
+	}
+}
+
+func TestOverviewHuman(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.json")
+	exitCode := withReadCommandTestDefaults(t, sessionPath, overviewCmd)
+	jsonMode = false
+	t.Cleanup(func() { jsonMode = true })
+	saveTestSession(t, sessionPath)
+
+	var mu sync.Mutex
+	http.DefaultTransport = testutil.RoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		var gqlReq struct {
+			OperationName string `json:"operationName"`
+		}
+		_ = json.NewDecoder(req.Body).Decode(&gqlReq)
+		mu.Lock()
+		defer mu.Unlock()
+		switch gqlReq.OperationName {
+		case "GetAccounts":
+			return testutil.JSONResponse(`{"data":{"accounts":[{"id":"a1","displayName":"Checking","type":{"name":"bank","display":"Bank"},"subtype":{"name":"checking","display":"Checking"},"displayBalance":1000,"currentBalance":1000,"updatedAt":"2026-05-01","isHidden":false,"isAsset":true,"mask":"1234","isManual":false,"includeInNetWorth":true,"includeBalanceInNetWorth":false}]}}`), nil
+		case "GetCashflowSummary":
+			return testutil.JSONResponse(`{"data":{"aggregates":[{"summary":{"sumIncome":5000,"sumExpense":3000,"savings":2000,"savingsRate":0.4}}]}}`), nil
+		case "GetTransactionsList":
+			return testutil.JSONResponse(`{"data":{"allTransactions":{"results":[{"id":"t1","date":"2026-07-01","amount":-50,"pending":false,"category":{"id":"c1","name":"Food","group":{"id":"g1","name":"Expenses","type":"expense"}},"merchant":{"name":"Grocery Store","id":"m1"},"account":{"id":"a1","displayName":"Checking","order":0,"type":{"group":"bank"}}}],"totalCount":42}}}`), nil
+		default:
+			return testutil.JSONResponse(`{"data":{}}`), nil
+		}
+	})
+
+	out := captureStdout(t, func() {
+		overviewCmd.Run(overviewCmd, nil)
+	})
+
+	if *exitCode != 0 {
+		t.Fatalf("exitCode = %d; output=%q", *exitCode, out)
+	}
+	if !strings.Contains(out, "Net Worth:") {
+		t.Fatalf("output missing Net Worth = %q", out)
+	}
+	if !strings.Contains(out, "Grocery Store") {
+		t.Fatalf("output missing merchant = %q", out)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,7 +32,7 @@ var (
 var RootCmd = &cobra.Command{
 	Use:     "monarch",
 	Short:   "A local, agent-friendly CLI for Monarch Money",
-	Version: version.Version,
+	Version: version.GetVersion(),
 	Long: `monarchmoney-cli is a single-binary command line tool for working with
 Monarch Money data from your terminal, scripts, and local agents.`,
 	Example: `  monarch accounts list --json
@@ -146,10 +146,10 @@ func writeVersion(out io.Writer, profileName string, jsonOut, prettyOut bool, du
 	if jsonOut {
 		renderer := output.NewRenderer(out, nil, true, prettyOut)
 		env := output.NewEnvelope("version", profileName, output.SchemaVersion, requestID, versionPayload{
-			Version: version.Version,
-			Commit:  version.Commit,
-			Date:    version.Date,
-			BuiltBy: version.BuiltBy,
+			Version: version.GetVersion(),
+			Commit:  version.GetCommit(),
+			Date:    version.GetDate(),
+			BuiltBy: version.GetBuiltBy(),
 		}, duration)
 		renderer.RenderSuccess(env)
 		return nil
@@ -157,6 +157,6 @@ func writeVersion(out io.Writer, profileName string, jsonOut, prettyOut bool, du
 
 	fmt.Fprint(out, monarchBanner)
 	fmt.Fprintln(out)
-	_, err := fmt.Fprintf(out, "monarch version %s (commit: %s, date: %s, built by: %s)\n", version.Version, version.Commit, version.Date, version.BuiltBy)
+	_, err := fmt.Fprintf(out, "monarch version %s (commit: %s, date: %s, built by: %s)\n", version.GetVersion(), version.GetCommit(), version.GetDate(), version.GetBuiltBy())
 	return err
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -37,7 +37,7 @@ type Report struct {
 // Check performs local system and configuration checks.
 func Check(ctx context.Context, connect bool) *Result {
 	res := &Result{
-		Version: version.Version,
+		Version: version.GetVersion(),
 		OS:      runtime.GOOS,
 		Arch:    runtime.GOARCH,
 	}

--- a/internal/errors/codes.go
+++ b/internal/errors/codes.go
@@ -10,6 +10,7 @@ const (
 	AuthMFAInvalid       Code = "AUTH_MFA_INVALID"
 	NetworkUnreachable   Code = "NETWORK_UNREACHABLE"
 	NetworkTimeout       Code = "NETWORK_TIMEOUT"
+	RateLimited          Code = "RATE_LIMITED"
 	APIError             Code = "API_ERROR"
 	APISchemaChanged     Code = "API_SCHEMA_CHANGED"
 	FEATURE_UNAVAILABLE  Code = "FEATURE_UNAVAILABLE"

--- a/internal/errors/codes_test.go
+++ b/internal/errors/codes_test.go
@@ -16,6 +16,7 @@ func TestCodeConstants(t *testing.T) {
 		{"AuthMFAInvalid", AuthMFAInvalid, "AUTH_MFA_INVALID"},
 		{"NetworkUnreachable", NetworkUnreachable, "NETWORK_UNREACHABLE"},
 		{"NetworkTimeout", NetworkTimeout, "NETWORK_TIMEOUT"},
+		{"RateLimited", RateLimited, "RATE_LIMITED"},
 		{"APIError", APIError, "API_ERROR"},
 		{"APISchemaChanged", APISchemaChanged, "API_SCHEMA_CHANGED"},
 		{"FEATURE_UNAVAILABLE", FEATURE_UNAVAILABLE, "FEATURE_UNAVAILABLE"},

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,15 +3,16 @@ package errors
 
 import (
 	"fmt"
+	"time"
 )
 
-// Error represents a structured CLI error.
 type Error struct {
-	Code      Code     `json:"code"`
-	Message   string   `json:"message"`
-	Category  Category `json:"category"`
-	Retryable bool     `json:"retryable"`
-	Err       error    `json:"-"`
+	Code         Code     `json:"code"`
+	Message      string   `json:"message"`
+	Category     Category `json:"category"`
+	Retryable    bool     `json:"retryable"`
+	RetryAfterMS int64    `json:"retry_after_ms,omitempty"`
+	Err          error    `json:"-"`
 }
 
 func (e *Error) Error() string {
@@ -21,7 +22,6 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
 }
 
-// New returns a new Error.
 func New(code Code, message string, category Category, retryable bool, err error) *Error {
 	return &Error{
 		Code:      code,
@@ -32,13 +32,25 @@ func New(code Code, message string, category Category, retryable bool, err error
 	}
 }
 
-// ExitCode returns the recommended process exit code for an error.
+func NewWithRetryAfter(code Code, message string, category Category, retryable bool, retryAfter time.Duration, err error) *Error {
+	return &Error{
+		Code:         code,
+		Message:      message,
+		Category:     category,
+		Retryable:    retryable,
+		RetryAfterMS: retryAfter.Milliseconds(),
+		Err:          err,
+	}
+}
+
 func (e *Error) ExitCode() int {
 	switch e.Code {
 	case AuthRequired, AuthSessionExpired, AuthMFARequired, AuthMFAInvalid:
 		return 3
 	case ReadOnlyViolation:
 		return 4
+	case RateLimited:
+		return 5
 	case NetworkUnreachable, NetworkTimeout:
 		return 5
 	case APIError, APISchemaChanged, FEATURE_UNAVAILABLE:

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -38,6 +38,7 @@ func TestExitCode(t *testing.T) {
 		{"read only", ReadOnlyViolation, 4},
 		{"network unreachable", NetworkUnreachable, 5},
 		{"network timeout", NetworkTimeout, 5},
+		{"rate limited", RateLimited, 5},
 		{"api error", APIError, 6},
 		{"schema changed", APISchemaChanged, 6},
 		{"feature unavailable", FEATURE_UNAVAILABLE, 6},

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -189,10 +189,16 @@ func (c *Client) doOnce(ctx context.Context, reqBody *Request, result any) error
 func parseRetryAfter(value string) time.Duration {
 	value = strings.TrimSpace(value)
 	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
+		if seconds > uint64(maxRetryWait/time.Second) {
+			return maxRetryWait
+		}
 		return time.Duration(seconds) * time.Second
 	}
 	if when, err := http.ParseTime(value); err == nil {
 		if duration := time.Until(when); duration > 0 {
+			if duration > maxRetryWait {
+				return maxRetryWait
+			}
 			return duration
 		}
 	}

--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -1,4 +1,3 @@
-// Package graphql implements a Monarch Money GraphQL client with retry and structured errors.
 package graphql
 
 import (
@@ -9,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,10 +24,11 @@ func UserAgent() string {
 	return DefaultUserAgent
 }
 
-// maxResponseBody bounds reads from the API so a malfunctioning server cannot OOM the CLI.
-const maxResponseBody = 50 * 1024 * 1024
-
-const maxRetries = 3
+const (
+	maxResponseBody = 10 << 20
+	maxRetries      = 3
+	maxRetryWait    = 10 * time.Second
+)
 
 type Request struct {
 	OperationName string         `json:"operationName"`
@@ -46,22 +47,59 @@ func (c *Client) TokenValue() string {
 }
 
 func NewClient(endpoint, token string, timeout time.Duration) *Client {
+	httpClient := &http.Client{
+		Timeout:       timeout,
+		CheckRedirect: rejectRedirects,
+	}
+	if transport, ok := http.DefaultTransport.(*http.Transport); ok {
+		cloned := transport.Clone()
+		cloned.MaxIdleConns = 16
+		cloned.MaxIdleConnsPerHost = 8
+		cloned.MaxConnsPerHost = 8
+		cloned.IdleConnTimeout = 90 * time.Second
+		httpClient.Transport = cloned
+	}
 	return &Client{
 		Endpoint: endpoint,
 		Token:    token,
-		HTTP:     &http.Client{Timeout: timeout},
+		HTTP:     httpClient,
 	}
 }
 
+func rejectRedirects(_ *http.Request, _ []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
 func (c *Client) Do(ctx context.Context, reqBody *Request, result any) error {
+	return c.doWithAttempts(ctx, reqBody, result, maxRetries+1)
+}
+
+// DoMutation executes a single attempt without retry. A transport failure can
+// occur after Monarch already accepted the mutation, making its outcome
+// ambiguous to the client; retrying would risk duplicating the write.
+func (c *Client) DoMutation(ctx context.Context, reqBody *Request, result any) error {
+	return c.doWithAttempts(ctx, reqBody, result, 1)
+}
+
+func (c *Client) doWithAttempts(ctx context.Context, reqBody *Request, result any, attempts int) error {
 	var lastErr error
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; attempt < attempts; attempt++ {
 		if attempt > 0 {
-			backoff := time.Duration(1<<uint(attempt-1)) * 500 * time.Millisecond
+			retryAfter := time.Duration(0)
+			if e, ok := lastErr.(*errors.Error); ok && e.RetryAfterMS > 0 {
+				retryAfter = time.Duration(e.RetryAfterMS) * time.Millisecond
+			}
+			if retryAfter > maxRetryWait {
+				return lastErr
+			}
+			delay := retryAfter
+			if delay <= 0 {
+				delay = time.Duration(1<<uint(attempt-1))*500*time.Millisecond + time.Duration(attempt)*37*time.Millisecond
+			}
 			select {
 			case <-ctx.Done():
 				return errors.New(errors.NetworkTimeout, "request canceled during retry backoff", errors.CatNetwork, false, ctx.Err())
-			case <-time.After(backoff):
+			case <-time.After(delay):
 			}
 		}
 
@@ -70,7 +108,7 @@ func (c *Client) Do(ctx context.Context, reqBody *Request, result any) error {
 			return nil
 		}
 
-		if e, ok := lastErr.(*errors.Error); ok && e.Retryable {
+		if e, ok := lastErr.(*errors.Error); ok && e.Retryable && attempt+1 < attempts {
 			continue
 		}
 		return lastErr
@@ -106,6 +144,16 @@ func (c *Client) doOnce(ctx context.Context, reqBody *Request, result any) error
 		return errors.New(errors.AuthSessionExpired, "session token expired or invalid; run `monarch auth login` again", errors.CatAuth, true, nil)
 	}
 
+	if resp.StatusCode == 429 {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return errors.NewWithRetryAfter(errors.RateLimited, "Monarch rate limit exceeded", errors.CatAPI, true, retryAfter, nil)
+	}
+
+	if resp.StatusCode >= 500 {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return errors.NewWithRetryAfter(errors.APIError, fmt.Sprintf("Monarch returned HTTP %d", resp.StatusCode), errors.CatAPI, true, retryAfter, nil)
+	}
+
 	if resp.StatusCode != 200 {
 		return errors.New(errors.APIError, fmt.Sprintf("API returned status %d", resp.StatusCode), errors.CatAPI, false, nil)
 	}
@@ -136,4 +184,17 @@ func (c *Client) doOnce(ctx context.Context, reqBody *Request, result any) error
 	}
 
 	return nil
+}
+
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseUint(value, 10, 64); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if duration := time.Until(when); duration > 0 {
+			return duration
+		}
+	}
+	return 0
 }

--- a/internal/graphql/client_test.go
+++ b/internal/graphql/client_test.go
@@ -19,6 +19,9 @@ func TestNewClient(t *testing.T) {
 	if client.Endpoint != "https://example.invalid/graphql" || client.Token != "token" || client.HTTP.Timeout != 3*time.Second {
 		t.Fatalf("NewClient() returned %#v", client)
 	}
+	if client.HTTP.CheckRedirect == nil {
+		t.Fatal("NewClient() HTTP.CheckRedirect is nil, want redirect rejection")
+	}
 }
 
 func TestTokenValue(t *testing.T) {
@@ -219,7 +222,6 @@ func TestDoDoesNotRetryNonRetryableErrors(t *testing.T) {
 }
 
 func TestDoResponseSizeLimit(t *testing.T) {
-	// Create a response larger than the 50MB limit.
 	bigBody := strings.Repeat("x", int(maxResponseBody)+1)
 	client := NewClient("https://example.invalid/graphql", "", 5*time.Second)
 	client.HTTP = &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
@@ -227,7 +229,6 @@ func TestDoResponseSizeLimit(t *testing.T) {
 	})}
 
 	err := client.Do(context.Background(), &Request{Query: "query { foo }"}, &struct{}{})
-	// Should fail because the oversized response is not valid JSON.
 	if err == nil {
 		t.Fatal("Do() error = nil, want failure for oversized response")
 	}
@@ -260,5 +261,96 @@ func TestUserAgentEnvOverride(t *testing.T) {
 	got := UserAgent()
 	if got != "CustomBot/1.0" {
 		t.Fatalf("UserAgent() = %q, want %q", got, "CustomBot/1.0")
+	}
+}
+
+func TestDoRateLimitedReturnsStructuredError(t *testing.T) {
+	client := NewClient("https://example.invalid/graphql", "", time.Second)
+	client.HTTP = &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": []string{"30"}}, Body: io.NopCloser(bytes.NewBufferString("{}"))}, nil
+	})}
+
+	err := client.Do(context.Background(), &Request{Query: "query { foo }"}, &struct{}{})
+	if err == nil {
+		t.Fatal("Do() error = nil, want rate-limit error")
+	}
+	var clierr *clierrors.Error
+	if !errors.As(err, &clierr) {
+		t.Fatalf("error type = %T, want *errors.Error", err)
+	}
+	if clierr.Code != clierrors.RateLimited {
+		t.Fatalf("code = %q, want %q", clierr.Code, clierrors.RateLimited)
+	}
+	if clierr.RetryAfterMS != 30000 {
+		t.Fatalf("retry_after_ms = %d, want 30000", clierr.RetryAfterMS)
+	}
+}
+
+func TestDoMutationDoesNotRetry(t *testing.T) {
+	attempts := 0
+	client := NewClient("https://example.invalid/graphql", "", 2*time.Second)
+	client.HTTP = &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return nil, errors.New("transient network error")
+	})}
+
+	err := client.DoMutation(context.Background(), &Request{Query: "mutation { delete }"}, &struct{}{})
+	if err == nil {
+		t.Fatal("DoMutation() error = nil, want failure")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry for mutations)", attempts)
+	}
+}
+
+func TestDoMutationSuccess(t *testing.T) {
+	client := NewClient("https://example.invalid/graphql", "", time.Second)
+	client.HTTP = &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewBufferString(`{"data":{"ok":true}}`))}, nil
+	})}
+
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.DoMutation(context.Background(), &Request{Query: "mutation { ok }"}, &result); err != nil {
+		t.Fatalf("DoMutation() error = %v", err)
+	}
+	if !result.OK {
+		t.Fatal("result.OK = false, want true")
+	}
+}
+
+func TestDoRejectsRedirects(t *testing.T) {
+	client := NewClient("https://example.invalid/graphql", "token", time.Second)
+	client.HTTP = &http.Client{
+		Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 302, Header: http.Header{"Location": []string{"https://evil.example/steal"}}, Body: io.NopCloser(bytes.NewBufferString(""))}, nil
+		}),
+		CheckRedirect: rejectRedirects,
+	}
+
+	err := client.Do(context.Background(), &Request{Query: "query { foo }"}, &struct{}{})
+	if err == nil {
+		t.Fatal("Do() error = nil, want failure for redirect response")
+	}
+}
+
+func TestParseRetryAfterSeconds(t *testing.T) {
+	if got := parseRetryAfter("42"); got != 42*time.Second {
+		t.Fatalf("parseRetryAfter(\"42\") = %v, want 42s", got)
+	}
+}
+
+func TestParseRetryAfterEmpty(t *testing.T) {
+	if got := parseRetryAfter(""); got != 0 {
+		t.Fatalf("parseRetryAfter(\"\") = %v, want 0", got)
+	}
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	future := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+	got := parseRetryAfter(future)
+	if got <= 0 || got > 3*time.Second {
+		t.Fatalf("parseRetryAfter(%q) = %v, want ~1-2s", future, got)
 	}
 }

--- a/internal/graphql/client_test.go
+++ b/internal/graphql/client_test.go
@@ -267,7 +267,7 @@ func TestUserAgentEnvOverride(t *testing.T) {
 func TestDoRateLimitedReturnsStructuredError(t *testing.T) {
 	client := NewClient("https://example.invalid/graphql", "", time.Second)
 	client.HTTP = &http.Client{Transport: testutil.RoundTripFunc(func(*http.Request) (*http.Response, error) {
-		return &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": []string{"30"}}, Body: io.NopCloser(bytes.NewBufferString("{}"))}, nil
+		return &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": []string{"5"}}, Body: io.NopCloser(bytes.NewBufferString("{}"))}, nil
 	})}
 
 	err := client.Do(context.Background(), &Request{Query: "query { foo }"}, &struct{}{})
@@ -281,8 +281,8 @@ func TestDoRateLimitedReturnsStructuredError(t *testing.T) {
 	if clierr.Code != clierrors.RateLimited {
 		t.Fatalf("code = %q, want %q", clierr.Code, clierrors.RateLimited)
 	}
-	if clierr.RetryAfterMS != 30000 {
-		t.Fatalf("retry_after_ms = %d, want 30000", clierr.RetryAfterMS)
+	if clierr.RetryAfterMS != 5000 {
+		t.Fatalf("retry_after_ms = %d, want 5000", clierr.RetryAfterMS)
 	}
 }
 
@@ -336,8 +336,15 @@ func TestDoRejectsRedirects(t *testing.T) {
 }
 
 func TestParseRetryAfterSeconds(t *testing.T) {
-	if got := parseRetryAfter("42"); got != 42*time.Second {
-		t.Fatalf("parseRetryAfter(\"42\") = %v, want 42s", got)
+	if got := parseRetryAfter("5"); got != 5*time.Second {
+		t.Fatalf("parseRetryAfter(\"5\") = %v, want 5s", got)
+	}
+}
+
+func TestParseRetryAfterCappedAtMaxWait(t *testing.T) {
+	got := parseRetryAfter("999999999")
+	if got != maxRetryWait {
+		t.Fatalf("parseRetryAfter(\"999999999\") = %v, want %v (capped)", got, maxRetryWait)
 	}
 }
 

--- a/internal/monarch/accounts.go
+++ b/internal/monarch/accounts.go
@@ -584,7 +584,7 @@ func (s *Service) CreateManualAccount(ctx context.Context, name, accType string,
 		} `json:"createManualAccount"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "CreateManualAccount",
 		Query:         CreateManualAccountMutation,
 		Variables: map[string]any{
@@ -619,7 +619,7 @@ func (s *Service) RefreshAccounts(ctx context.Context, accountIDs []string) erro
 		variables["accountIds"] = accountIDs
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "RefreshAccounts",
 		Query:         RefreshAccountsMutation,
 		Variables:     variables,
@@ -645,7 +645,7 @@ func (s *Service) UpdateAccount(ctx context.Context, id string, name *string, ba
 		variables["balance"] = *balance
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "UpdateAccount",
 		Query:         UpdateAccountMutation,
 		Variables:     variables,
@@ -669,7 +669,7 @@ func (s *Service) DeleteAccount(ctx context.Context, id string) error {
 		} `json:"deleteAccount"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "DeleteAccount",
 		Query:         DeleteAccountMutation,
 		Variables:     map[string]any{"id": id},

--- a/internal/monarch/budgets.go
+++ b/internal/monarch/budgets.go
@@ -80,7 +80,7 @@ func (s *Service) UpdateFlexibleBudget(ctx context.Context, month, year int, amo
 		} `json:"updateOrCreateFlexBudgetItem"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "UpdateFlexibleBudget",
 		Query:         UpdateFlexibleBudgetMutation,
 		Variables: map[string]any{
@@ -102,7 +102,7 @@ func (s *Service) UpdateFlexRolloverSettings(ctx context.Context, startMonth str
 		} `json:"updateBudgetSettings"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "UpdateFlexRolloverSettings",
 		Query:         UpdateFlexRolloverSettingsMutation,
 		Variables: map[string]any{
@@ -182,7 +182,7 @@ func (s *Service) SetBudget(ctx context.Context, categoryID string, amount float
 		},
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "SetBudget",
 		Query:         SetBudgetMutation,
 		Variables:     variables,
@@ -205,7 +205,7 @@ func (s *Service) ResetBudget(ctx context.Context, month, year int) error {
 		} `json:"resetBudget"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "ResetBudget",
 		Query:         ResetBudgetMutation,
 		Variables:     map[string]any{"month": month, "year": year},

--- a/internal/monarch/categories.go
+++ b/internal/monarch/categories.go
@@ -119,7 +119,7 @@ func (s *Service) CreateCategory(ctx context.Context, name, groupID string) (*Ca
 		} `json:"createCategory"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "CreateCategory",
 		Query:         CreateCategoryMutation,
 		Variables: map[string]any{
@@ -145,7 +145,7 @@ func (s *Service) DeleteCategory(ctx context.Context, id string) error {
 		} `json:"deleteCategory"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "DeleteCategory",
 		Query:         DeleteCategoryMutation,
 		Variables:     map[string]any{"id": id},
@@ -159,7 +159,7 @@ func (s *Service) DeleteCategories(ctx context.Context, ids []string) error {
 		} `json:"deleteTransactionCategories"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "DeleteCategories",
 		Query:         DeleteCategoriesMutation,
 		Variables:     map[string]any{"ids": ids},

--- a/internal/monarch/overview.go
+++ b/internal/monarch/overview.go
@@ -1,0 +1,80 @@
+package monarch
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type FinancialOverview struct {
+	AsOf             string           `json:"as_of"`
+	NetWorth         float64          `json:"net_worth"`
+	AccountCount     int              `json:"account_count"`
+	Cashflow         *CashflowSummary `json:"cashflow"`
+	Transactions     []Transaction    `json:"transactions"`
+	TransactionTotal int              `json:"transaction_total"`
+}
+
+func (s *Service) GetFinancialOverview(ctx context.Context, startDate, endDate string) (*FinancialOverview, error) {
+	if startDate == "" || endDate == "" {
+		now := time.Now()
+		startDate = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).Format("2006-01-02")
+		endDate = time.Date(now.Year(), now.Month()+1, 0, 0, 0, 0, 0, now.Location()).Format("2006-01-02")
+	}
+
+	var accounts []Account
+	var cashflow *CashflowSummary
+	var transactions []Transaction
+	var txTotal int
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		var err error
+		accounts, err = s.ListAccounts(groupCtx)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		cashflow, err = s.GetCashflowSummary(groupCtx, startDate, endDate)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		transactions, txTotal, err = s.ListTransactions(groupCtx, &ListTransactionsOptions{
+			StartDate: startDate,
+			EndDate:   endDate,
+			Limit:     10,
+		})
+		return err
+	})
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	netWorth := 0.0
+	visibleCount := 0
+	for i := range accounts {
+		a := &accounts[i]
+		if a.DeactivatedAt != "" || a.IsHidden {
+			continue
+		}
+		visibleCount++
+		if a.IncludeInNetWorth || a.IncludeBalanceInNetWorth {
+			if a.IsAsset {
+				netWorth += a.DisplayBalance
+			} else {
+				netWorth -= a.DisplayBalance
+			}
+		}
+	}
+
+	return &FinancialOverview{
+		AsOf:             time.Now().UTC().Format(time.RFC3339),
+		NetWorth:         netWorth,
+		AccountCount:     visibleCount,
+		Cashflow:         cashflow,
+		Transactions:     transactions,
+		TransactionTotal: txTotal,
+	}, nil
+}

--- a/internal/monarch/recurring.go
+++ b/internal/monarch/recurring.go
@@ -142,7 +142,7 @@ func (s *Service) UpdateRecurring(ctx context.Context, id string, amount float64
 		} `json:"updateRecurringTransaction"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "UpdateRecurringTransaction",
 		Query:         UpdateRecurringMutation,
 		Variables: map[string]any{

--- a/internal/monarch/rules.go
+++ b/internal/monarch/rules.go
@@ -187,7 +187,7 @@ func (s *Service) CreateRule(ctx context.Context, input *CreateRuleInput) error 
 		} `json:"createTransactionRuleV2"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_CreateTransactionRuleMutationV2",
 		Query:         CreateTransactionRuleMutation,
 		Variables:     map[string]any{"input": ruleInput},
@@ -230,7 +230,7 @@ func (s *Service) UpdateRule(ctx context.Context, input *UpdateRuleInput) error 
 		} `json:"updateTransactionRuleV2"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_UpdateTransactionRuleMutationV2",
 		Query:         UpdateTransactionRuleMutation,
 		Variables:     map[string]any{"input": ruleInput},
@@ -254,7 +254,7 @@ func (s *Service) DeleteRule(ctx context.Context, id string) error {
 		} `json:"deleteTransactionRule"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_DeleteTransactionRule",
 		Query:         DeleteTransactionRuleMutation,
 		Variables:     map[string]any{"id": id},

--- a/internal/monarch/service.go
+++ b/internal/monarch/service.go
@@ -9,6 +9,7 @@ import (
 
 type graphQLClient interface {
 	Do(ctx context.Context, reqBody *graphql.Request, result any) error
+	DoMutation(ctx context.Context, reqBody *graphql.Request, result any) error
 	TokenValue() string
 }
 

--- a/internal/monarch/service_test.go
+++ b/internal/monarch/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/thedavidweng/monarchmoney-cli/internal/graphql"
@@ -43,6 +45,14 @@ func (*fakeCSVWriter) Flush() {}
 func (w *fakeCSVWriter) Error() error { return w.err }
 
 func (m *mockClient) Do(_ context.Context, req *graphql.Request, result any) error {
+	m.lastReq = req
+	if m.handler != nil {
+		return m.handler(req, result)
+	}
+	return nil
+}
+
+func (m *mockClient) DoMutation(_ context.Context, req *graphql.Request, result any) error {
 	m.lastReq = req
 	if m.handler != nil {
 		return m.handler(req, result)
@@ -1243,4 +1253,76 @@ func isNilValue(v any) bool {
 		return rv.IsNil()
 	}
 	return false
+}
+
+func TestGetFinancialOverview(t *testing.T) {
+	calls := 0
+	var mu sync.Mutex
+	var client *mockClient
+	client = &mockClient{
+		token: "token-123",
+		handler: func(req *graphql.Request, result any) error {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			switch req.OperationName {
+			case "GetAccounts":
+				return client.respond(result, `{"accounts":[{"id":"a1","displayName":"Checking","type":{"name":"bank"},"displayBalance":1000,"isAsset":true,"includeInNetWorth":true}]}`)
+			case "GetCashflowSummary":
+				return client.respond(result, `{"aggregates":[{"summary":{"sumIncome":200,"sumExpense":100,"savings":100,"savingsRate":50}}]}`)
+			case "GetTransactionsList":
+				return client.respond(result, `{"allTransactions":{"results":[{"id":"tx-1","date":"2026-01-01","amount":10,"merchant":{"name":"Paycheck"},"category":{"name":"Income"}}],"totalCount":1}}`)
+			default:
+				return fmt.Errorf("unexpected operation %s", req.OperationName)
+			}
+		},
+	}
+
+	ov, err := NewService(client).GetFinancialOverview(context.Background(), "2026-01-01", "2026-01-31")
+	mustNoErr(t, err)
+	mustNotNil(t, ov)
+	eq(t, 1, ov.AccountCount)
+	eq(t, 1000.0, ov.NetWorth)
+	mustNotNil(t, ov.Cashflow)
+	eq(t, 50.0, ov.Cashflow.SavingsRate)
+	eq(t, 1, ov.TransactionTotal)
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3 (concurrent fetches)", calls)
+	}
+}
+
+func TestGetFinancialOverviewDefaultsToCurrentMonth(t *testing.T) {
+	var client *mockClient
+	client = &mockClient{
+		token: "token-123",
+		handler: func(req *graphql.Request, result any) error {
+			switch req.OperationName {
+			case "GetAccounts":
+				return client.respond(result, `{"accounts":[]}`)
+			case "GetCashflowSummary":
+				return client.respond(result, `{"aggregates":[{"summary":{"sumIncome":0,"sumExpense":0,"savings":0,"savingsRate":0}}]}`)
+			case "GetTransactionsList":
+				return client.respond(result, `{"allTransactions":{"results":[],"totalCount":0}}`)
+			default:
+				return fmt.Errorf("unexpected operation %s", req.OperationName)
+			}
+		},
+	}
+
+	ov, err := NewService(client).GetFinancialOverview(context.Background(), "", "")
+	mustNoErr(t, err)
+	mustNotNil(t, ov)
+	eq(t, 0, ov.AccountCount)
+}
+
+func TestGetFinancialOverviewPropagatesErrors(t *testing.T) {
+	client := &mockClient{
+		token: "token-123",
+		handler: func(req *graphql.Request, result any) error {
+			return errors.New("boom")
+		},
+	}
+
+	_, err := NewService(client).GetFinancialOverview(context.Background(), "2026-01-01", "2026-01-31")
+	hasErr(t, err)
 }

--- a/internal/monarch/service_test.go
+++ b/internal/monarch/service_test.go
@@ -22,6 +22,7 @@ import (
 
 type mockClient struct {
 	token   string
+	mu      sync.Mutex
 	lastReq *graphql.Request
 	handler func(req *graphql.Request, result any) error
 }
@@ -45,7 +46,9 @@ func (*fakeCSVWriter) Flush() {}
 func (w *fakeCSVWriter) Error() error { return w.err }
 
 func (m *mockClient) Do(_ context.Context, req *graphql.Request, result any) error {
+	m.mu.Lock()
 	m.lastReq = req
+	m.mu.Unlock()
 	if m.handler != nil {
 		return m.handler(req, result)
 	}
@@ -53,7 +56,9 @@ func (m *mockClient) Do(_ context.Context, req *graphql.Request, result any) err
 }
 
 func (m *mockClient) DoMutation(_ context.Context, req *graphql.Request, result any) error {
+	m.mu.Lock()
 	m.lastReq = req
+	m.mu.Unlock()
 	if m.handler != nil {
 		return m.handler(req, result)
 	}

--- a/internal/monarch/tags.go
+++ b/internal/monarch/tags.go
@@ -57,7 +57,7 @@ func (s *Service) CreateTag(ctx context.Context, name, color string) (*Tag, erro
 		} `json:"createHouseholdTransactionTag"`
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "CreateTag",
 		Query:         CreateTagMutation,
 		Variables: map[string]any{

--- a/internal/monarch/transactions.go
+++ b/internal/monarch/transactions.go
@@ -333,7 +333,7 @@ func (s *Service) UpdateTransaction(ctx context.Context, id string, notes, categ
 		input["needsReview"] = *needsReview
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Web_TransactionDrawerUpdateTransaction",
 		Query:         UpdateTransactionMutation,
 		Variables:     map[string]any{"input": input},
@@ -362,7 +362,7 @@ func (s *Service) DeleteTransaction(ctx context.Context, id string) error {
 		} `json:"deleteTransaction"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_DeleteTransactionMutation",
 		Query:         DeleteTransactionMutation,
 		Variables: map[string]any{
@@ -402,7 +402,7 @@ func (s *Service) UpdateTransactionSplits(ctx context.Context, txID string, spli
 		splitData[i] = sd
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_SplitTransactionMutation",
 		Query:         UpdateTransactionSplitsMutation,
 		Variables: map[string]any{
@@ -448,7 +448,7 @@ func (s *Service) CreateTransaction(ctx context.Context, amount float64, merchan
 		},
 	}
 
-	err := s.Client.Do(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_CreateTransactionMutation",
 		Query:         CreateTransactionMutation,
 		Variables:     variables,
@@ -475,7 +475,7 @@ func (s *Service) SetTransactionTags(ctx context.Context, txID string, tagIDs []
 		} `json:"setTransactionTags"`
 	}
 
-	return s.Client.Do(ctx, &graphql.Request{
+	return s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Web_SetTransactionTags",
 		Query:         SetTransactionTagsMutation,
 		Variables: map[string]any{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,12 +1,79 @@
 package version
 
+import (
+	"fmt"
+	"runtime/debug"
+	"sync"
+)
+
 var (
-	// Version is the current version of the CLI. Set at build time via ldflags.
 	Version = "dev"
-	// Commit is the git commit hash at build time.
-	Commit = "none"
-	// Date is the build date.
-	Date = "unknown"
-	// BuiltBy is the entity that built the binary.
+	Commit  = "none"
+	Date    = "unknown"
 	BuiltBy = "unknown"
 )
+
+var (
+	once  sync.Once
+	build *debug.BuildInfo
+)
+
+func resolve() {
+	once.Do(func() {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+		build = info
+		if Commit == "none" {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.revision" && setting.Value != "" {
+					Commit = setting.Value
+					break
+				}
+			}
+		}
+		if Date == "unknown" {
+			for _, setting := range info.Settings {
+				if setting.Key == "vcs.time" && setting.Value != "" {
+					Date = setting.Value
+					break
+				}
+			}
+		}
+		if Version == "dev" && info.Main.Version != "" && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	})
+}
+
+func GetVersion() string {
+	resolve()
+	return Version
+}
+
+func GetCommit() string {
+	resolve()
+	if len(Commit) > 12 {
+		return Commit[:12]
+	}
+	return Commit
+}
+
+func GetDate() string {
+	resolve()
+	return Date
+}
+
+func GetBuiltBy() string {
+	resolve()
+	return BuiltBy
+}
+
+func GetBuildInfo() string {
+	resolve()
+	if build == nil {
+		return "build info unavailable"
+	}
+	return fmt.Sprintf("go %s, module %s, path %s", build.GoVersion, build.Main.Path, build.Path)
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -25,6 +25,15 @@ func TestGetCommitTruncatesLongHash(t *testing.T) {
 	}
 }
 
+func TestGetCommitShortHashUntruncated(t *testing.T) {
+	original := Commit
+	Commit = "abc123"
+	defer func() { Commit = original }()
+	if got := GetCommit(); got != "abc123" {
+		t.Fatalf("GetCommit() = %q, want %q", got, "abc123")
+	}
+}
+
 func TestGetDateDefault(t *testing.T) {
 	if got := GetDate(); got == "" {
 		t.Fatal("GetDate() = empty, want non-empty")
@@ -41,5 +50,14 @@ func TestGetBuildInfoReturnsString(t *testing.T) {
 	got := GetBuildInfo()
 	if got == "" {
 		t.Fatal("GetBuildInfo() = empty, want non-empty")
+	}
+}
+
+func TestGetBuildInfoUnavailableWhenBuildNil(t *testing.T) {
+	original := build
+	build = nil
+	defer func() { build = original }()
+	if got := GetBuildInfo(); got != "build info unavailable" {
+		t.Fatalf("GetBuildInfo() = %q, want %q", got, "build info unavailable")
 	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,45 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestGetVersionDefault(t *testing.T) {
+	if got := GetVersion(); got == "" {
+		t.Fatal("GetVersion() = empty, want non-empty")
+	}
+}
+
+func TestGetCommitDefault(t *testing.T) {
+	if got := GetCommit(); got == "" {
+		t.Fatal("GetCommit() = empty, want non-empty")
+	}
+}
+
+func TestGetCommitTruncatesLongHash(t *testing.T) {
+	original := Commit
+	Commit = "abcdef1234567890abcdef1234567890abcdef12"
+	defer func() { Commit = original }()
+	if got := GetCommit(); got != "abcdef123456" {
+		t.Fatalf("GetCommit() = %q, want %q", got, "abcdef123456")
+	}
+}
+
+func TestGetDateDefault(t *testing.T) {
+	if got := GetDate(); got == "" {
+		t.Fatal("GetDate() = empty, want non-empty")
+	}
+}
+
+func TestGetBuiltByDefault(t *testing.T) {
+	if got := GetBuiltBy(); got == "" {
+		t.Fatal("GetBuiltBy() = empty, want non-empty")
+	}
+}
+
+func TestGetBuildInfoReturnsString(t *testing.T) {
+	got := GetBuildInfo()
+	if got == "" {
+		t.Fatal("GetBuildInfo() = empty, want non-empty")
+	}
+}

--- a/tests/e2e/binary_test.go
+++ b/tests/e2e/binary_test.go
@@ -253,7 +253,7 @@ var requiredCommands = []string{
 	"accounts", "analyze", "audit", "auth", "budgets",
 	"cache", "cashflow", "categories", "credit",
 	"doctor", "goals", "institutions", "investments",
-	"networth", "recurring", "rules", "subscription",
+	"networth", "overview", "recurring", "rules", "subscription",
 	"tags", "transactions", "version",
 }
 
@@ -402,6 +402,12 @@ func TestBinary_Doctor_JSON(t *testing.T) {
 func TestBinary_Goals_Help(t *testing.T) {
 	bin := buildBinary(t)
 	stdout, code := run(t, bin, "goals", "--help")
+	requireZero(t, code, stdout)
+}
+
+func TestBinary_Overview_Help(t *testing.T) {
+	bin := buildBinary(t)
+	stdout, code := run(t, bin, "overview", "--help")
 	requireZero(t, code, stdout)
 }
 


### PR DESCRIPTION
## Summary

Cherry-picks high-value features from `matteing/monarch-cli`, adapted to this repo's standards (ADR, structured errors, JSON envelope, tests, comment budget).

- **Reject HTTP redirects** in GraphQL and login clients (`CheckRedirect` returns `http.ErrUseLastResponse`). A misconfigured endpoint or hostile intermediary can no longer silently redirect the bearer token to an attacker-controlled host.
- **Mutation no-retry**: new `Client.DoMutation` executes exactly one attempt. All 21 mutation methods across accounts, budgets, categories, recurring, rules, tags, and transactions now use it. A transport failure after a successful write is ambiguous; retrying risks duplicating the effect. Reads keep the existing retry loop.
- **Rate-limit handling**: HTTP 429 produces a new `RATE_LIMITED` error code (exit 5) with the parsed `Retry-After` value (seconds or HTTP-date) stored in a new `Error.RetryAfterMS` field. 5xx responses also parse `Retry-After` and stay retryable. The retry loop honours `RetryAfterMS` when present, capped at 10s.
- **`monarch overview` command**: concurrent fetch of accounts, cashflow summary, and 10 most recent transactions via `golang.org/x/sync/errgroup`, with net worth computed from visible, net-worth-included accounts. `--from`/`--to` default to the current month.
- **VCS-aware build info**: `version.GetVersion`/`GetCommit`/`GetDate` resolve from `runtime/debug.ReadBuildInfo` (`vcs.revision`, `vcs.time`, module version) when ldflags aren't set, so `go build` without `-ldflags` still reports a meaningful commit and date.
- **ADR 0007** documents the decisions and the new `golang.org/x/sync` dependency.

#### Test plan

- [x] `mise run check` (fmt + build + test + lint + conventions) passes
- [x] New tests: rate-limit error, mutation no-retry, redirect rejection, Retry-After parsing (seconds/empty/HTTP-date), overview service method (concurrent fetch, default month, error propagation), version getters, e2e overview help
- [x] All existing tests pass
- [x] COMMANDS.md and JSON_SCHEMA.md updated with overview command and `RATE_LIMITED` error code
- [x] ADR 0007 created