### PR TITLE
docs: remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
   <a href="https://github.com/thedavidweng/monarchmoney-cli/releases"><img src="https://img.shields.io/github/v/release/thedavidweng/monarchmoney-cli?style=flat-square" alt="Release"></a>
   <a href="https://github.com/thedavidweng/monarchmoney-cli/blob/main/LICENSE"><img src="https://img.shields.io/github/license/thedavidweng/monarchmoney-cli?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/go-%3E%3D1.26-blue?style=flat-square" alt="Go">
-  <a href="https://goreportcard.com/report/github.com/thedavidweng/monarchmoney-cli"><img src="https://goreportcard.com/badge/github.com/thedavidweng/monarchmoney-cli?style=flat-square" alt="Go Report"></a>
 </p>
 
 `monarchmoney-cli` lets you query, manage, and automate Monarch Money data from the terminal or via AI agents, with stable JSON output and explicit safety gates around financial mutations.


### PR DESCRIPTION
One-line cleanup carried over from the feat/hledger-backup worktree: Go Report Card is retired, so its badge no longer renders. Removes it from README.

🤖 Generated with opencode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Go Report Card badge from the README.
  * Retained the CI, release, license, and Go version badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->