### PR TITLE
chore(ci): pin reusable workflows to immutable SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   ci:
-    uses: thedavidweng/cli-workflow-template/.github/workflows/go-ci.yml@main
+    uses: thedavidweng/cli-workflow-template/.github/workflows/go-ci.yml@87904abb6c0938e078a439474aebfba9b571a55e # main
     with:
       enable-coverage: true
       enable-conventions: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   release:
-    uses: thedavidweng/cli-workflow-template/.github/workflows/go-release.yml@main
+    uses: thedavidweng/cli-workflow-template/.github/workflows/go-release.yml@87904abb6c0938e078a439474aebfba9b571a55e # main
     secrets: inherit


### PR DESCRIPTION
Pin reusable workflows to an immutable commit SHA.

Replaces `@main` with `@87904abb6c0938e078a439474aebfba9b571a55e` (`# main`) for all `thedavidweng/cli-workflow-template` reusable workflow references, per org-wide policy of pinning GitHub Actions to immutable SHAs.

Note: after this change the repo no longer follows template updates automatically. Future template updates arrive via Dependabot (github-actions, weekly — already configured in `dependabot.yml`) or can be applied manually by bumping the SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and release workflows to use fixed workflow revisions, improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->