### PR TITLE
fix(accounts): send input objects for account mutations

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -94,7 +94,7 @@ All mutations are protected by the [Safety Model](./docs/safety.md).
 - `monarch auth login`: Authenticate and persist session.
 - `monarch auth logout`: Remove the local session token.
 - `monarch accounts refresh [account-id...]`: Trigger a remote sync of all accounts (or specific ones).
-- `monarch accounts create-manual`: Create a manual account.
+- `monarch accounts create-manual`: Create a manual account. Requires `--name` and `--subtype`; `--type` defaults to `cash`.
 - `monarch accounts update <id>`: Update account name or balance.
 - `monarch accounts delete <id>`: Delete an account.
 - `monarch accounts upload-history <id>`: Upload balance history for an account.

--- a/internal/cli/accounts.go
+++ b/internal/cli/accounts.go
@@ -19,6 +19,7 @@ var (
 	accountName    string
 	accountBalance float64
 	accountType    string
+	accountSubtype string
 	historyFrom    string
 	historyTo      string
 	refreshWait    bool
@@ -272,9 +273,9 @@ var accountsCreateManualCmd = &cobra.Command{
 		runMutation(cmd, "accounts.create-manual", "failed to create manual account", safety.TierMutation, func() (mutation, *errors.Error) {
 			var acc *monarch.Account
 			return mutation{
-				planAfter: map[string]any{"name": accountName, "type": accountType, "balance": accountBalance},
+				planAfter: map[string]any{"name": accountName, "type": accountType, "subtype": accountSubtype, "balance": accountBalance},
 				do: func(ctx context.Context, svc *monarch.Service) (any, error) {
-					a, err := svc.CreateManualAccount(ctx, accountName, accountType, accountBalance)
+					a, err := svc.CreateManualAccount(ctx, accountName, accountType, accountSubtype, accountBalance)
 					if err != nil {
 						return nil, err
 					}
@@ -438,8 +439,10 @@ var networthCmd = &cobra.Command{
 func init() {
 	accountsCreateManualCmd.Flags().StringVar(&accountName, "name", "", "account name")
 	accountsCreateManualCmd.Flags().StringVar(&accountType, "type", "cash", "account type (e.g. cash, credit, investment)")
+	accountsCreateManualCmd.Flags().StringVar(&accountSubtype, "subtype", "", "account subtype (e.g. checking, credit_card, other)")
 	accountsCreateManualCmd.Flags().Float64Var(&accountBalance, "balance", 0, "initial balance")
-	accountsCreateManualCmd.MarkFlagRequired("name") //nolint:errcheck // flag registered above
+	accountsCreateManualCmd.MarkFlagRequired("name")    //nolint:errcheck // flag registered above
+	accountsCreateManualCmd.MarkFlagRequired("subtype") //nolint:errcheck // flag registered above
 
 	accountsUpdateCmd.Flags().StringVar(&accountName, "name", "", "new account name")
 	accountsUpdateCmd.Flags().Float64Var(&accountBalance, "balance", 0, "new account balance")

--- a/internal/cli/accounts_test.go
+++ b/internal/cli/accounts_test.go
@@ -325,7 +325,7 @@ func testAccountsRefreshJSON(t *testing.T) {
 		if gqlReq.OperationName != "Common_ForceRefreshAccountsMutation" {
 			t.Fatalf("operation = %q, want Common_ForceRefreshAccountsMutation", gqlReq.OperationName)
 		}
-		return testutil.JSONResponse(`{"data":{"requestAccountsRefresh":{"ok":true}}}`), nil
+		return testutil.JSONResponse(`{"data":{"forceRefreshAccounts":{"success":true,"errors":null}}}`), nil
 	})
 
 	out := captureStdout(t, func() {
@@ -394,10 +394,11 @@ func testAccountsUpdateJSON(t *testing.T) {
 		if gqlReq.OperationName != "Common_UpdateAccount" {
 			t.Fatalf("operation = %q, want Common_UpdateAccount", gqlReq.OperationName)
 		}
-		if gqlReq.Variables["id"] != "acc-1" {
-			t.Fatalf("variables = %#v, want id=acc-1", gqlReq.Variables)
+		input, _ := gqlReq.Variables["input"].(map[string]any)
+		if input["id"] != "acc-1" || input["name"] != "New" || input["displayBalance"] != 100.0 {
+			t.Fatalf("input = %#v, want id=acc-1 name=New displayBalance=100", input)
 		}
-		return testutil.JSONResponse(`{"data":{"updateAccount":{"account":{"id":"acc-1","displayName":"New","displayBalance":100}}}}`), nil
+		return testutil.JSONResponse(`{"data":{"updateAccount":{"account":{"id":"acc-1","displayName":"New","displayBalance":100},"errors":null}}}`), nil
 	})
 
 	accountName = ""
@@ -442,7 +443,7 @@ func testAccountsDeleteJSON(t *testing.T) {
 		if gqlReq.Variables["id"] != "acc-1" {
 			t.Fatalf("variables = %#v, want id=acc-1", gqlReq.Variables)
 		}
-		return testutil.JSONResponse(`{"data":{"deleteAccount":{"ok":true}}}`), nil
+		return testutil.JSONResponse(`{"data":{"deleteAccount":{"deleted":true,"errors":null}}}`), nil
 	})
 
 	out := captureStdout(t, func() {
@@ -477,20 +478,23 @@ func testAccountsCreateManualJSON(t *testing.T) {
 		if gqlReq.OperationName != "Web_CreateManualAccount" {
 			t.Fatalf("operation = %q, want Web_CreateManualAccount", gqlReq.OperationName)
 		}
-		if gqlReq.Variables["name"] != "Savings" {
-			t.Fatalf("variables = %#v, want name=Savings", gqlReq.Variables)
+		input, _ := gqlReq.Variables["input"].(map[string]any)
+		if input["name"] != "Savings" || input["type"] != "cash" || input["subtype"] != "checking" {
+			t.Fatalf("input = %#v, want name=Savings type=cash subtype=checking", input)
 		}
-		if gqlReq.Variables["type"] != "cash" {
-			t.Fatalf("variables = %#v, want type=cash", gqlReq.Variables)
+		if input["displayBalance"] != 10.0 || input["includeInNetWorth"] != true {
+			t.Fatalf("input = %#v, want displayBalance=10 includeInNetWorth=true", input)
 		}
-		return testutil.JSONResponse(`{"data":{"createManualAccount":{"account":{"id":"a2","displayName":"Savings","displayBalance":10}}}}`), nil
+		return testutil.JSONResponse(`{"data":{"createManualAccount":{"account":{"id":"a2","displayName":"Savings","displayBalance":10},"errors":null}}}`), nil
 	})
 
 	accountName = ""
 	accountType = ""
+	accountSubtype = ""
 	accountBalance = 0
 	_ = accountsCreateManualCmd.Flags().Set("name", "Savings")
 	_ = accountsCreateManualCmd.Flags().Set("type", "cash")
+	_ = accountsCreateManualCmd.Flags().Set("subtype", "checking")
 	_ = accountsCreateManualCmd.Flags().Set("balance", "10")
 	out := captureStdout(t, func() {
 		accountsCreateManualCmd.Run(accountsCreateManualCmd, nil)

--- a/internal/monarch/accounts.go
+++ b/internal/monarch/accounts.go
@@ -637,7 +637,7 @@ func (s *Service) ListAccounts(ctx context.Context) ([]Account, error) {
 	return accounts, nil
 }
 
-func (s *Service) CreateManualAccount(ctx context.Context, name, accType string, balance float64) (*Account, error) {
+func (s *Service) CreateManualAccount(ctx context.Context, name, accType, subtype string, balance float64) (*Account, error) {
 	var resp struct {
 		CreateManualAccount struct {
 			Account struct {
@@ -645,6 +645,9 @@ func (s *Service) CreateManualAccount(ctx context.Context, name, accType string,
 				DisplayName    string  `json:"displayName"`
 				DisplayBalance float64 `json:"displayBalance"`
 			} `json:"account"`
+			Errors *struct {
+				Message string `json:"message"`
+			} `json:"errors"`
 		} `json:"createManualAccount"`
 	}
 
@@ -652,14 +655,22 @@ func (s *Service) CreateManualAccount(ctx context.Context, name, accType string,
 		OperationName: "Web_CreateManualAccount",
 		Query:         CreateManualAccountMutation,
 		Variables: map[string]any{
-			"name":    name,
-			"type":    accType,
-			"balance": balance,
+			"input": map[string]any{
+				"type":              accType,
+				"subtype":           subtype,
+				"includeInNetWorth": true,
+				"name":              name,
+				"displayBalance":    balance,
+			},
 		},
 	}, &resp)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.CreateManualAccount.Errors != nil && resp.CreateManualAccount.Errors.Message != "" {
+		return nil, errors.New(errors.APIError, resp.CreateManualAccount.Errors.Message, errors.CatAPI, false, nil)
 	}
 
 	return &Account{
@@ -671,21 +682,36 @@ func (s *Service) CreateManualAccount(ctx context.Context, name, accType string,
 
 func (s *Service) RefreshAccounts(ctx context.Context, accountIDs []string) error {
 	var resp struct {
-		RequestAccountsRefresh struct {
-			OK bool `json:"ok"`
-		} `json:"requestAccountsRefresh"`
+		ForceRefreshAccounts struct {
+			Success bool `json:"success"`
+			Errors  *struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		} `json:"forceRefreshAccounts"`
 	}
 
-	variables := make(map[string]any)
+	input := make(map[string]any)
 	if len(accountIDs) > 0 {
-		variables["accountIds"] = accountIDs
+		input["accountIds"] = accountIDs
 	}
 
-	return s.Client.DoMutation(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_ForceRefreshAccountsMutation",
 		Query:         RefreshAccountsMutation,
-		Variables:     variables,
+		Variables:     map[string]any{"input": input},
 	}, &resp)
+	if err != nil {
+		return err
+	}
+
+	if !resp.ForceRefreshAccounts.Success {
+		msg := "failed to refresh accounts"
+		if resp.ForceRefreshAccounts.Errors != nil && resp.ForceRefreshAccounts.Errors.Message != "" {
+			msg = resp.ForceRefreshAccounts.Errors.Message
+		}
+		return errors.New(errors.APIError, msg, errors.CatAPI, false, nil)
+	}
+	return nil
 }
 
 func (s *Service) UpdateAccount(ctx context.Context, id string, name *string, balance *float64) (*Account, error) {
@@ -696,25 +722,32 @@ func (s *Service) UpdateAccount(ctx context.Context, id string, name *string, ba
 				DisplayName    string  `json:"displayName"`
 				DisplayBalance float64 `json:"displayBalance"`
 			} `json:"account"`
+			Errors *struct {
+				Message string `json:"message"`
+			} `json:"errors"`
 		} `json:"updateAccount"`
 	}
 
-	variables := map[string]any{"id": id}
+	input := map[string]any{"id": id}
 	if name != nil {
-		variables["displayName"] = *name
+		input["name"] = *name
 	}
 	if balance != nil {
-		variables["balance"] = *balance
+		input["displayBalance"] = *balance
 	}
 
 	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_UpdateAccount",
 		Query:         UpdateAccountMutation,
-		Variables:     variables,
+		Variables:     map[string]any{"input": input},
 	}, &resp)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.UpdateAccount.Errors != nil && resp.UpdateAccount.Errors.Message != "" {
+		return nil, errors.New(errors.APIError, resp.UpdateAccount.Errors.Message, errors.CatAPI, false, nil)
 	}
 
 	return &Account{
@@ -727,15 +760,30 @@ func (s *Service) UpdateAccount(ctx context.Context, id string, name *string, ba
 func (s *Service) DeleteAccount(ctx context.Context, id string) error {
 	var resp struct {
 		DeleteAccount struct {
-			OK bool `json:"ok"`
+			Deleted bool `json:"deleted"`
+			Errors  *struct {
+				Message string `json:"message"`
+			} `json:"errors"`
 		} `json:"deleteAccount"`
 	}
 
-	return s.Client.DoMutation(ctx, &graphql.Request{
+	err := s.Client.DoMutation(ctx, &graphql.Request{
 		OperationName: "Common_DeleteAccount",
 		Query:         DeleteAccountMutation,
 		Variables:     map[string]any{"id": id},
 	}, &resp)
+	if err != nil {
+		return err
+	}
+
+	if !resp.DeleteAccount.Deleted {
+		msg := "failed to delete account"
+		if resp.DeleteAccount.Errors != nil && resp.DeleteAccount.Errors.Message != "" {
+			msg = resp.DeleteAccount.Errors.Message
+		}
+		return errors.New(errors.APIError, msg, errors.CatAPI, false, nil)
+	}
+	return nil
 }
 
 var (

--- a/internal/monarch/service_test.go
+++ b/internal/monarch/service_test.go
@@ -224,8 +224,9 @@ func testServiceAccountsCoreMutationPaths(t *testing.T) {
 	t.Helper()
 
 	t.Run("create manual account", func(t *testing.T) {
-		runGraphQLCase(t, "Web_CreateManualAccount", map[string]any{"name": "Savings", "type": "bank", "balance": 10.0}, `{"createManualAccount":{"account":{"id":"a2","displayName":"Savings","displayBalance":10}}}`, func(s *Service) error {
-			got, err := s.CreateManualAccount(context.Background(), "Savings", "bank", 10)
+		wantInput := map[string]any{"input": map[string]any{"type": "bank", "subtype": "checking", "includeInNetWorth": true, "name": "Savings", "displayBalance": 10.0}}
+		runGraphQLCase(t, "Web_CreateManualAccount", wantInput, `{"createManualAccount":{"account":{"id":"a2","displayName":"Savings","displayBalance":10},"errors":null}}`, func(s *Service) error {
+			got, err := s.CreateManualAccount(context.Background(), "Savings", "bank", "checking", 10)
 			mustNoErr(t, err)
 			mustNotNil(t, got)
 			eq(t, "a2", got.ID)
@@ -235,10 +236,26 @@ func testServiceAccountsCoreMutationPaths(t *testing.T) {
 		})
 	})
 
+	t.Run("create manual account payload error", func(t *testing.T) {
+		var client *mockClient
+		client = &mockClient{
+			token: "token-123",
+			handler: func(req *graphql.Request, result any) error {
+				assertReq(t, req, "Web_CreateManualAccount")
+				return client.respond(result, `{"createManualAccount":{"account":null,"errors":{"message":"subtype is required"}}}`)
+			},
+		}
+		_, err := NewService(client).CreateManualAccount(context.Background(), "Savings", "bank", "", 10)
+		if err == nil || !strings.Contains(err.Error(), "subtype is required") {
+			t.Fatalf("CreateManualAccount() error = %v, want 'subtype is required'", err)
+		}
+	})
+
 	t.Run("update account", func(t *testing.T) {
 		name := "New name"
 		balance := 11.25
-		runGraphQLCase(t, "Common_UpdateAccount", map[string]any{"id": "acc-1", "displayName": name, "balance": balance}, `{"updateAccount":{"account":{"id":"acc-1","displayName":"New name","displayBalance":11.25}}}`, func(s *Service) error {
+		wantInput := map[string]any{"input": map[string]any{"id": "acc-1", "name": name, "displayBalance": balance}}
+		runGraphQLCase(t, "Common_UpdateAccount", wantInput, `{"updateAccount":{"account":{"id":"acc-1","displayName":"New name","displayBalance":11.25},"errors":null}}`, func(s *Service) error {
 			got, err := s.UpdateAccount(context.Background(), "acc-1", &name, &balance)
 			mustNoErr(t, err)
 			mustNotNil(t, got)
@@ -248,16 +265,92 @@ func testServiceAccountsCoreMutationPaths(t *testing.T) {
 		})
 	})
 
+	t.Run("update account payload error", func(t *testing.T) {
+		var client *mockClient
+		client = &mockClient{
+			token: "token-123",
+			handler: func(req *graphql.Request, result any) error {
+				assertReq(t, req, "Common_UpdateAccount")
+				return client.respond(result, `{"updateAccount":{"account":null,"errors":{"message":"account not found"}}}`)
+			},
+		}
+		_, err := NewService(client).UpdateAccount(context.Background(), "acc-1", nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "account not found") {
+			t.Fatalf("UpdateAccount() error = %v, want 'account not found'", err)
+		}
+	})
+
 	t.Run("refresh accounts", func(t *testing.T) {
-		runGraphQLCase(t, "Common_ForceRefreshAccountsMutation", map[string]any{"accountIds": []string{"a1", "a2"}}, `{"requestAccountsRefresh":{"ok":true}}`, func(s *Service) error {
+		wantInput := map[string]any{"input": map[string]any{"accountIds": []string{"a1", "a2"}}}
+		runGraphQLCase(t, "Common_ForceRefreshAccountsMutation", wantInput, `{"forceRefreshAccounts":{"success":true,"errors":null}}`, func(s *Service) error {
 			return s.RefreshAccounts(context.Background(), []string{"a1", "a2"})
 		})
 	})
 
+	t.Run("refresh accounts not successful", func(t *testing.T) {
+		var client *mockClient
+		client = &mockClient{
+			token: "token-123",
+			handler: func(req *graphql.Request, result any) error {
+				assertReq(t, req, "Common_ForceRefreshAccountsMutation")
+				return client.respond(result, `{"forceRefreshAccounts":{"success":false,"errors":{"message":"refresh unavailable"}}}`)
+			},
+		}
+		err := NewService(client).RefreshAccounts(context.Background(), nil)
+		if err == nil || !strings.Contains(err.Error(), "refresh unavailable") {
+			t.Fatalf("RefreshAccounts() error = %v, want 'refresh unavailable'", err)
+		}
+	})
+
+	t.Run("refresh accounts blank payload message", func(t *testing.T) {
+		var client *mockClient
+		client = &mockClient{
+			token: "token-123",
+			handler: func(req *graphql.Request, result any) error {
+				assertReq(t, req, "Common_ForceRefreshAccountsMutation")
+				return client.respond(result, `{"forceRefreshAccounts":{"success":false,"errors":{"message":""}}}`)
+			},
+		}
+		err := NewService(client).RefreshAccounts(context.Background(), nil)
+		if err == nil || !strings.Contains(err.Error(), "failed to refresh accounts") {
+			t.Fatalf("RefreshAccounts() error = %v, want 'failed to refresh accounts'", err)
+		}
+	})
+
 	t.Run("delete account", func(t *testing.T) {
-		runGraphQLCase(t, "Common_DeleteAccount", map[string]any{"id": "acc-1"}, `{"deleteAccount":{"ok":true}}`, func(s *Service) error {
+		runGraphQLCase(t, "Common_DeleteAccount", map[string]any{"id": "acc-1"}, `{"deleteAccount":{"deleted":true,"errors":null}}`, func(s *Service) error {
 			return s.DeleteAccount(context.Background(), "acc-1")
 		})
+	})
+
+	t.Run("delete account blank payload message", func(t *testing.T) {
+		var client *mockClient
+		client = &mockClient{
+			token: "token-123",
+			handler: func(req *graphql.Request, result any) error {
+				assertReq(t, req, "Common_DeleteAccount")
+				return client.respond(result, `{"deleteAccount":{"deleted":false,"errors":{"message":""}}}`)
+			},
+		}
+		err := NewService(client).DeleteAccount(context.Background(), "acc-1")
+		if err == nil || !strings.Contains(err.Error(), "failed to delete account") {
+			t.Fatalf("DeleteAccount() error = %v, want 'failed to delete account'", err)
+		}
+	})
+
+	t.Run("delete account not deleted", func(t *testing.T) {
+		var client *mockClient
+		client = &mockClient{
+			token: "token-123",
+			handler: func(req *graphql.Request, result any) error {
+				assertReq(t, req, "Common_DeleteAccount")
+				return client.respond(result, `{"deleteAccount":{"deleted":false,"errors":{"message":"account not found"}}}`)
+			},
+		}
+		err := NewService(client).DeleteAccount(context.Background(), "acc-1")
+		if err == nil || !strings.Contains(err.Error(), "account not found") {
+			t.Fatalf("DeleteAccount() error = %v, want 'account not found'", err)
+		}
 	})
 }
 
@@ -1020,12 +1113,12 @@ func TestServiceErrorBranches(t *testing.T) {
 		runGraphQLErrorCase(t, "AccountDetails_getAccount", map[string]any{"id": "acc-1"}, func(s *Service) error { _, err := s.GetAccount(context.Background(), "acc-1"); return err })
 		runGraphQLErrorCase(t, "GetAccountTypeOptions", nil, func(s *Service) error { _, err := s.GetAccountTypes(context.Background()); return err })
 		runGraphQLErrorCase(t, "ForceRefreshAccountsQuery", nil, func(s *Service) error { _, err := s.GetAccountsRefreshStatus(context.Background()); return err })
-		runGraphQLErrorCase(t, "Web_CreateManualAccount", map[string]any{"name": "Savings", "type": "bank", "balance": 10.0}, func(s *Service) error {
-			_, err := s.CreateManualAccount(context.Background(), "Savings", "bank", 10)
+		runGraphQLErrorCase(t, "Web_CreateManualAccount", map[string]any{"input": map[string]any{"type": "bank", "subtype": "checking", "includeInNetWorth": true, "name": "Savings", "displayBalance": 10.0}}, func(s *Service) error {
+			_, err := s.CreateManualAccount(context.Background(), "Savings", "bank", "checking", 10)
 			return err
 		})
-		runGraphQLErrorCase(t, "Common_UpdateAccount", map[string]any{"id": "acc-1"}, func(s *Service) error { _, err := s.UpdateAccount(context.Background(), "acc-1", nil, nil); return err })
-		runGraphQLErrorCase(t, "Common_ForceRefreshAccountsMutation", map[string]any{}, func(s *Service) error { return s.RefreshAccounts(context.Background(), nil) })
+		runGraphQLErrorCase(t, "Common_UpdateAccount", map[string]any{"input": map[string]any{"id": "acc-1"}}, func(s *Service) error { _, err := s.UpdateAccount(context.Background(), "acc-1", nil, nil); return err })
+		runGraphQLErrorCase(t, "Common_ForceRefreshAccountsMutation", map[string]any{"input": map[string]any{}}, func(s *Service) error { return s.RefreshAccounts(context.Background(), nil) })
 		runGraphQLErrorCase(t, "Common_DeleteAccount", map[string]any{"id": "acc-1"}, func(s *Service) error { return s.DeleteAccount(context.Background(), "acc-1") })
 		runGraphQLErrorCase(t, "Web_GetHoldings", nil, func(s *Service) error { _, err := s.GetAccountHoldings(context.Background(), "acc-1"); return err })
 		runGraphQLErrorCase(t, "GetAccountHistory", map[string]any{"filters": map[string]any{}}, func(s *Service) error {

--- a/queries/accounts/create_manual.graphql
+++ b/queries/accounts/create_manual.graphql
@@ -1,9 +1,12 @@
-mutation Web_CreateManualAccount($name: String!, $type: String!, $balance: Float!) {
-  createManualAccount(name: $name, type: $type, balance: $balance) {
+mutation Web_CreateManualAccount($input: CreateManualAccountMutationInput!) {
+  createManualAccount(input: $input) {
     account {
       id
       displayName
       displayBalance
+    }
+    errors {
+      message
     }
   }
 }

--- a/queries/accounts/delete.graphql
+++ b/queries/accounts/delete.graphql
@@ -1,5 +1,8 @@
-mutation Common_DeleteAccount($id: ID!) {
+mutation Common_DeleteAccount($id: UUID!) {
   deleteAccount(id: $id) {
-    ok
+    deleted
+    errors {
+      message
+    }
   }
 }

--- a/queries/accounts/refresh.graphql
+++ b/queries/accounts/refresh.graphql
@@ -1,5 +1,8 @@
-mutation Common_ForceRefreshAccountsMutation($accountIds: [UUID!]) {
-  requestAccountsRefresh(accountIds: $accountIds) {
-    ok
+mutation Common_ForceRefreshAccountsMutation($input: ForceRefreshAccountsInput!) {
+  forceRefreshAccounts(input: $input) {
+    success
+    errors {
+      message
+    }
   }
 }

--- a/queries/accounts/update.graphql
+++ b/queries/accounts/update.graphql
@@ -1,9 +1,12 @@
-mutation Common_UpdateAccount($id: ID!, $displayName: String, $balance: Float) {
-  updateAccount(id: $id, displayName: $displayName, balance: $balance) {
+mutation Common_UpdateAccount($input: UpdateAccountMutationInput!) {
+  updateAccount(input: $input) {
     account {
       id
       displayName
       displayBalance
+    }
+    errors {
+      message
     }
   }
 }


### PR DESCRIPTION
Every `monarch accounts` write returns HTTP 400: Monarch's account mutations take `input:` objects, and the CLI still sends the old positional arguments. Reads are unaffected. Reproduced on v0.7.0 and v0.9.0.

| Mutation | Before | After |
| --- | --- | --- |
| `updateAccount` | `updateAccount(id:, displayName:, balance:)` | `updateAccount(input: UpdateAccountMutationInput!)` with `id`, `name`, `displayBalance` |
| `createManualAccount` | `createManualAccount(name:, type:, balance:)` | `createManualAccount(input: CreateManualAccountMutationInput!)` with `type`, `subtype`, `includeInNetWorth`, `name`, `displayBalance` |
| `deleteAccount` | `($id: ID!)`, returns `ok` | `($id: UUID!)`, returns `deleted` |
| `requestAccountsRefresh` | `requestAccountsRefresh(accountIds:)`, returns `ok` | `forceRefreshAccounts(input: ForceRefreshAccountsInput!)`, returns `success` |

`subtype` is now required by the `createManualAccount` resolver, so `accounts create-manual` gains a required `--subtype` flag (e.g. `--type other_asset --subtype other`). `deleteAccount` is the one account mutation that still takes a positional argument. Each mutation now selects and surfaces its payload `errors.message` rather than reporting success on a failed write.

Verified against the live API for all four mutations, and cross-checked against the shapes used by `hammem/monarchmoney`. `go build ./...`, `go test ./...` and `golangci-lint run` pass; existing tests that asserted the old shapes were updated and failure-path coverage added for each mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual account creation now requires an account subtype, while account type defaults to cash.
  * Account operations now surface clearer API error messages.

* **Bug Fixes**
  * Updated account creation, editing, deletion, and refresh operations to use the latest API behavior.
  * Improved handling of unsuccessful account operations and refresh requests.

* **Documentation**
  * Updated command documentation to reflect the required account name and subtype options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->